### PR TITLE
docs: close fresh Strix Halo install gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,23 @@ documented optional DSpark drafter.
 
 ## Quick start
 
-Both nodes need ROCm support for `gfx1151`, passwordless SSH between them, and
-their own local copy of the same repository commit and GGUF at the same
-absolute paths. Their filesystems are not shared.
+Both nodes need ROCm support for `gfx1151`, passwordless SSH from the
+coordinator to the worker, and their own local copy of the same repository
+commit and GGUF at the same absolute paths. Their filesystems are not shared.
+
+Follow [DS4 on Strix Halo](STRIXHALO.md) for the Ubuntu 26.04 ROCm 7.14
+tarball, rocWMMA header isolation, memory-layout decision, Secure Boot check,
+and coordinator-to-worker SSH setup. Ubuntu 26.04 apt currently supplies ROCm
+7.1; it is not a substitute for the validated 7.14 bundle.
 
 Build on both nodes:
 
 ```sh
 git clone https://github.com/wkljohn/ds4-strix-halo-tp-odinlink.git
 cd ds4-strix-halo-tp-odinlink
+HIP_PATH=/absolute/path/to/rocm-7.14.0 \
+CPATH=/absolute/path/to/rocm-7.14.0/include \
+CPLUS_INCLUDE_PATH=/absolute/path/to/rocm-7.14.0/include \
 DS4_ROCM_HOME=/absolute/path/to/rocm-7.14.0 \
   make -j"$(nproc)" strix-halo
 ```
@@ -129,16 +137,19 @@ validated userspace provider is pinned below:
 
 ```sh
 sudo apt install build-essential cmake linux-headers-"$(uname -r)" \
-  libibverbs-dev rdma-core pkg-config
+  libibverbs-dev rdma-core pkg-config libglib2.0-dev
 git clone https://github.com/wkljohn/OdinLink-Five.git
 git -C OdinLink-Five checkout 8a77ccbf051b5a615a2b4d9a75ede10af524614a
 cmake -S OdinLink-Five -B OdinLink-Five/build \
-  -DBUILD_VERBS=ON -DBUILD_TRAY=OFF
+  -DBUILD_VERBS=ON -DBUILD_DAEMON=ON -DBUILD_TRAY=OFF
 cmake --build OdinLink-Five/build -j"$(nproc)" \
-  --target odl_tb5_verbs odl_tb5_verbs_provider
+  --target driver odl_tb5_cli odl_tb5_verbs odl_tb5_verbs_provider
 ```
 
-After loading the driver, verify the device and link before loading the model:
+Disable Secure Boot or enroll a trusted module-signing key before loading the
+out-of-tree driver. Load it on both nodes; the character device is created only
+after both peers advertise the OdinLink Thunderbolt service. Then verify the
+device and link before loading the model:
 
 ```sh
 ls -l /dev/odl_tb5_0

--- a/STRIXHALO.md
+++ b/STRIXHALO.md
@@ -1,43 +1,59 @@
 # DS4 on Strix Halo
 
-This is the minimal setup for DS4 ROCm inference on a
-Strix Halo machine with 128 GB RAM and Radeon 8060S (`gfx1151`).
+This is the bare-metal setup for DS4 ROCm inference on a Strix Halo machine
+with 128 GiB of physical memory and a Radeon 8060S (`gfx1151`). Apply the same
+ROCm and build setup on both tensor-parallel nodes.
 
-## 1. Install ROCm
+## 1. Install one ROCm toolchain
 
-On Ubuntu 26.04 LTS, install the ROCm compiler/runtime and libraries used by the Strix Halo backend:
+Ubuntu 26.04's ROCm packages provide ROCm 7.1, not the ROCm 7.14 toolchain
+validated by this branch. Install the gfx1151 TheRock bundle separately. The
+bundle used for the current deployment is:
+
+```text
+https://rocm.prereleases.amd.com/tarball-multi-arch/therock-dist-linux-gfx1151-7.14.0rc3.tar.gz
+```
+
+Extract it as `/opt/rocm-7.14.0` and verify the resulting root before building:
+
+```sh
+test -x /opt/rocm-7.14.0/bin/hipcc
+/opt/rocm-7.14.0/bin/hipcc --version
+```
+
+Install the host-side build dependencies, but do **not** install Ubuntu's
+`librocwmma-dev` alongside the bundle:
 
 ```sh
 sudo apt-get update
-sudo apt-get install -y \
-  hipcc rocminfo rocm-smi \
-  libamdhip64-dev \
-  libhipblas-dev libhipblaslt-dev \
-  librocblas-dev \
-  librocwmma-dev \
-  libhipcub-dev
+sudo apt-get install -y build-essential cmake pkg-config \
+  linux-headers-"$(uname -r)" libibverbs-dev rdma-core libglib2.0-dev mokutil
+sudo apt-get remove -y librocwmma-dev
 ```
 
-The backend uses rocWMMA. On this Ubuntu 26.04 setup, `librocwmma-dev`
-installs the top-level rocWMMA headers but misses `rocwmma/internal/`.
-No Ubuntu package currently provides those internal headers. Install a complete
-matching rocWMMA header tree:
+`hipcc` can otherwise find `/usr/include/rocwmma/rocwmma.hpp` before the
+bundle's matching headers. Ubuntu's header tree has no `rocwmma/internal/`, so
+the build then fails at `internal/accessors.hpp`. Do not combine Ubuntu's
+rocWMMA headers, a manually copied `/usr/local/include/rocwmma`, and TheRock.
+Removing the foreign header packages/copies is the preferred repair. If a
+managed machine cannot remove them, its build wrapper must put
+`-isystem /opt/rocm-7.14.0/include` before all system include paths.
+
+Do not create `/opt/rocm` symlinks to `/usr`. Select the complete installation
+explicitly:
 
 ```sh
-git clone --depth 1 --branch rocm-7.1.0 https://github.com/ROCm/rocWMMA.git /tmp/rocWMMA-rocm-7.1.0
-sudo mkdir -p /usr/local/include
-sudo cp -a /tmp/rocWMMA-rocm-7.1.0/library/include/rocwmma /usr/local/include/
+HIP_PATH=/opt/rocm-7.14.0 \
+CPATH=/opt/rocm-7.14.0/include \
+CPLUS_INCLUDE_PATH=/opt/rocm-7.14.0/include \
+DS4_ROCM_HOME=/opt/rocm-7.14.0 \
+  make -j"$(nproc)" strix-halo
 ```
 
-If ROCm is installed under `/usr` but tooling expects `/opt/rocm`, add these
-compatibility links:
-
-```sh
-sudo mkdir -p /opt/rocm/bin
-sudo ln -sf /usr/bin/hipcc /opt/rocm/bin/hipcc
-sudo ln -sfn /usr/lib/x86_64-linux-gnu /opt/rocm/lib
-sudo ln -sfn /usr/include /opt/rocm/include
-```
+These include exports are the tested fresh-install recipe and keep the TheRock
+header tree ahead of `/usr/include`. `make rocm` is an alias for
+`make strix-halo`. Check the compiler printed by the build if a host has ever
+had more than one ROCm installation.
 
 ## 2. Enable ROCm access
 
@@ -50,87 +66,144 @@ sudo usermod -aG render,video "$USER"
 Log out and back in, or reboot. Verify:
 
 ```sh
-rocminfo | grep -A80 'Name:                    gfx1151'
+/opt/rocm-7.14.0/bin/rocminfo | grep -A80 'Name:                    gfx1151'
 ```
 
-If DS4 says `no ROCm-capable device is detected`, check that `rocminfo` can open
-`/dev/kfd` and that `groups` includes `render`.
+If DS4 says `no ROCm-capable device is detected`, check that `rocminfo` can
+open `/dev/kfd` and that `groups` includes `render`.
 
-## 3. Increase GPU-visible memory
+## 3. Classify memory before changing GTT
 
-A 128 GB Strix Halo system may initially expose only about 62 GB of GPU-visible
-memory. DS4 needs the larger GTT aperture for the 80.76 GiB model plus runtime
-buffers.
+Strix Halo firmware can expose memory in two materially different ways. Check
+the GPU-visible VRAM and remaining operating-system RAM first:
 
-Use these kernel parameters:
+```sh
+for f in /sys/class/drm/card*/device/mem_info_vram_total; do
+  printf '%s: ' "$f"
+  numfmt --to=iec < "$f"
+done
+free -h
+cat /proc/cmdline
+```
+
+If `mem_info_vram_total` is already about **96 GiB** and the OS has only about
+**30 GiB**, make no GTT change. Adding `amdgpu.gttsize=126976` on that firmware
+policy oversubscribes the same 128 GiB of physical memory.
+
+The large-GTT recipe below is only for the opposite firmware policy: a small
+VRAM carve-out with most RAM left to the OS. On such a host, and only after
+confirming that layout, the known recipe is:
 
 ```text
 amd_iommu=off amdgpu.gttsize=126976 ttm.pages_limit=32505856 ttm.page_pool_size=32505856
 ```
 
-On Ubuntu with GRUB:
+After changing GRUB and rebooting, verify `/proc/cmdline`, the VRAM/GTT kernel
+messages, `rocminfo`, and `free -h` again. Never copy this stanza between
+machines solely because they have the same processor or total RAM.
+
+The 96 GiB field setup used `amd_iommu=off`, but the observation did not prove
+that OdinLink requires it. Treat IOMMU policy as a separate platform decision;
+do not infer it from the VRAM/GTT classification alone.
+
+## 4. Prepare OdinLink on both nodes
+
+Check Secure Boot before building or loading the out-of-tree driver:
 
 ```sh
-sudo cp /etc/default/grub /etc/default/grub.bak
-sudoedit /etc/default/grub
+mokutil --sb-state
+cat /sys/module/module/parameters/sig_enforce 2>/dev/null || true
 ```
 
-Set:
+With Secure Boot/EFI lockdown enforcing signatures, an unsigned
+`odl_tb5.ko` fails with `Key was rejected by service`. This cannot be repaired
+over SSH by rebuilding or retrying `insmod`: disable Secure Boot in UEFI
+firmware (or establish a signed-module/MOK workflow), reboot, and check again.
 
-```text
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash amd_iommu=off amdgpu.gttsize=126976 ttm.pages_limit=32505856 ttm.page_pool_size=32505856"
-```
-
-Then:
+OdinLink's daemon remains enabled when the tray is disabled, so
+`libglib2.0-dev` is required even with `-DBUILD_TRAY=OFF`:
 
 ```sh
-sudo update-grub
-sudo reboot
+git clone https://github.com/wkljohn/OdinLink-Five.git
+git -C OdinLink-Five checkout 8a77ccbf051b5a615a2b4d9a75ede10af524614a
+cmake -S OdinLink-Five -B OdinLink-Five/build \
+  -DBUILD_VERBS=ON -DBUILD_DAEMON=ON -DBUILD_TRAY=OFF
+cmake --build OdinLink-Five/build -j"$(nproc)" \
+  --target driver odl_tb5_cli odl_tb5_verbs odl_tb5_verbs_provider
 ```
 
-After reboot, verify:
+`libfuse3-dev` and `libssl-dev` enable optional daemon file-access and sync
+features; DS4's verbs transport does not require them.
+
+Load the built driver on **both** nodes. Loading one side is not sufficient:
+`/dev/odl_tb5_0` appears only after both Thunderbolt peers advertise the
+`tbsvc:kodinlink...` service and bind successfully. Confirm both sides before
+starting DS4:
 
 ```sh
-cat /proc/cmdline
-sudo dmesg | grep -Ei 'GTT|gttsize|TTM|VRAM'
-rocminfo | grep -A80 'Name:                    gfx1151'
+sudo insmod OdinLink-Five/driver/odl_tb5.ko
+sudo dmesg | grep -E 'tbsvc:kodinlink|odl_tb5'
+ls -l /dev/odl_tb5_0
 ```
 
-Expected signs:
+A `thunderbolt-net` interface or IP address on `thunderbolt0` is not an
+OdinLink device and does not satisfy this check. Do not start a one-sided DS4
+run until `/dev/odl_tb5_0` exists on both ranks.
 
-```text
-amdgpu:  126976M of GTT memory ready
-rocminfo gfx1151 pool: 130023424 KB
-```
+## 5. Preserve the management network
 
-## 4. Build DS4
+Keep Ubuntu Desktop's existing NetworkManager ownership of the management
+interface. Do not add a netplan file with `renderer: networkd` for the whole
+host: it can take the Ethernet interface away from NetworkManager, renew DHCP,
+and change the address used for SSH.
 
-Use the normal Strix Halo target. It builds the standard binary names:
+Use the ordinary Ethernet/Wi-Fi management address for SSH. Keep it separate
+from any Thunderbolt or RDMA data-path address, and do not depend on the
+OdinLink link for recovery access.
+
+Create a NetworkManager profile for the Thunderbolt data address instead of a
+host-wide `networkd` netplan file. Use `.1` on the coordinator and `.2` on the
+worker:
 
 ```sh
-make strix-halo -j"$(nproc)"
+sudo nmcli connection add type ethernet ifname thunderbolt0 \
+  con-name odinlink-tb ipv4.method manual ipv4.addresses 10.4.0.1/24 \
+  ipv4.never-default yes ipv6.method disabled
+sudo nmcli connection up odinlink-tb
 ```
 
-`make rocm` is an alias for `make strix-halo`.
+This profile must not change the NetworkManager connection for the management
+interface. Set `COORDINATOR_RDMA_ADDR` to the coordinator's Thunderbolt address.
 
-## 5. Use the right GGUF
-
-Use the standard IQ2XXS/Q2K/Q8 imatrix GGUF:
-
-```text
-DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix.gguf
-```
-
-Avoid the mixed IQ2/IQ4 or IQ2/Q4 GGUFs on this machine for now. They put much
-more memory pressure on the ROCm path and can trigger system OOM instead of a
-clean DS4 failure.
-
-## 6. Run DS4
-
-Run it normally:
+The deployment launcher SSHes **from the coordinator to the worker**. Create
+and install the key in that direction, then prove the exact configured alias
+works non-interactively:
 
 ```sh
-./ds4 -m gguf/DeepSeek-V4-Flash-IQ2XXS-w2Q2K-AProjQ8-SExpQ8-OutQ8-chat-v2-imatrix.gguf
+# Run on the coordinator.
+ssh-keygen -t ed25519
+ssh-copy-id user@worker-management-address
+ssh -o HostKeyAlias=ds4-worker-management \
+  user@worker-management-address true
+ssh -o BatchMode=yes -o StrictHostKeyChecking=yes \
+  -o HostKeyAlias=ds4-worker-management \
+  user@worker-management-address true
 ```
 
-The ROCm build uses the Strix Halo backend automatically.
+Set `PEER_MGMT` to that management destination and `PEER_HOST_KEY_ALIAS` to
+the same unique alias used above. Do not reuse a Thunderbolt IP that identifies
+another fabric. The first SSH command using `HostKeyAlias` records the trusted
+key under the exact name the launcher's `StrictHostKeyChecking=yes` lookup
+will use.
+
+## 6. Verify artifacts and run
+
+The nodes have independent filesystems. Finish copying the GGUF before launch,
+then verify the repository commit, executable hashes, model size, and sampled
+model fingerprint on both sides. The benchmark and deployment launchers
+perform these checks and refuse transport fallback.
+
+For OdinLink, also run the standalone server/client test documented in the
+main [README](README.md#odinlink-over-usb4tb5) before loading the model. Use the
+standard Q4_K model listed there; mixed target-model layouts that are not in
+the compatibility table remain unsupported.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,6 +22,12 @@ deploy/ds4-tp-caddy.sh status
 `config.env.local`. Startup fails closed if that pin does not match, so a stale
 coordinator cannot use a different TP gate schedule from the worker.
 
+Run the launcher on the coordinator. It opens an SSH session from the
+coordinator to `PEER_MGMT`; install that coordinator user's public key on the
+worker and verify `ssh -o BatchMode=yes` succeeds first. Keep `PEER_MGMT` on an
+independent NetworkManager-managed Ethernet or Wi-Fi address, not an OdinLink
+or Thunderbolt address.
+
 The launcher starts both independent model loads together, validates the
 selected RDMA provider plus matching binary and sampled model fingerprints,
 and refuses to replace unrelated processes. It uses a 262,144-token context
@@ -77,9 +83,35 @@ deploy/ds4-tp-caddy.sh stop
 caddy validate --config /etc/caddy/Caddyfile
 ```
 
-The local Caddy route should proxy to `127.0.0.1:8090` with streaming flush
-enabled and a response timeout long enough for initial model loading. Keep
-port 8090 loopback-only; do not bypass Caddy's authentication at the firewall.
+The launcher requires Caddy to be installed, configured, and active before
+`start`. A fresh Ubuntu image can be bootstrapped with:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y caddy
+sudoedit /etc/caddy/Caddyfile
+```
+
+A minimal local configuration for the initial preflight is:
+
+```caddyfile
+:8080 {
+    reverse_proxy 127.0.0.1:8090
+}
+```
+
+Validate and activate it:
+
+```sh
+sudo caddy validate --config /etc/caddy/Caddyfile
+sudo systemctl enable --now caddy
+systemctl is-active caddy
+```
+
+Replace the bootstrap listener with the production TLS/authentication route as
+appropriate. It should proxy to `127.0.0.1:8090` with streaming flush enabled
+and a response timeout long enough for initial model loading. Keep port 8090
+loopback-only; do not bypass Caddy's authentication at the firewall.
 
 ## Agent-client completion limits
 

--- a/deploy/config.env.example
+++ b/deploy/config.env.example
@@ -12,7 +12,7 @@ MTP=/absolute/path/DeepSeek-V4-Flash-DSpark-support-Q8_0.gguf
 
 # Management SSH is separate from the OdinLink/RDMA data path.
 PEER_MGMT=user@peer-management-address
-PEER_HOST_KEY_ALIAS=peer-rdma-host-key-alias
+PEER_HOST_KEY_ALIAS=ds4-worker-management
 COORDINATOR_RDMA_ADDR=10.4.0.1
 
 # Transport profile: odinlink (default) or roce-v2. For the reference


### PR DESCRIPTION
## Summary

- isolate TheRock ROCm 7.14 from Ubuntu rocWMMA headers
- classify 96 GiB UMA versus large-GTT firmware before changing GRUB
- document Secure Boot, two-sided OdinLink enumeration, NetworkManager, SSH, and Caddy preflights
- build every OdinLink artifact used by the guide

## Review

- PASS from Claude Fable 5.1 (`claude-fable-5-1`)
- `git diff --check`
- `DS4_RESEARCH_ROOT=/home/wkljohn/Desktop/cc/research-results ./scripts/check-research-root-contract.sh`
