### PR TITLE
Add mlx4 TP transport with hardened Podman deployment

### DIFF
--- a/ODINLINK.md
+++ b/ODINLINK.md
@@ -14,8 +14,10 @@ export LD_LIBRARY_PATH=/path/to/odinlink/lib
 ```
 
 Without `DS4_TP_VERBS_LIB`, DS4 loads the system `libibverbs` directly. This
-keeps native providers such as Mellanox `mlx5` outside the OdinLink shim and
-preserves the existing generic 16 KiB decode-message framing. OdinLink devices
+keeps native providers such as Mellanox `mlx5` and `mlx4` outside the OdinLink
+shim and preserves the existing generic 16 KiB decode-message framing.
+InfiniBand ports without an IPv4-mapped GID fall back to GID 0 automatically.
+OdinLink devices
 named `odl_tb5_*` negotiate a 128 KiB limit, allowing a normal 28,672-byte
 decode vector to use one message. `DS4_TP_RDMA_DECODE_MAX_MSG` can override the
 local advertised limit; the peers use the lower value.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,8 +1,9 @@
 # ds4-strix-halo-tp-odinlink project
 
 This fork develops cache-free tensor-parallel DeepSeek inference for AMD Strix
-Halo across mandatory OdinLink or mlx5 RoCE v2 RDMA, including ordinary greedy
-decode and opt-in DSpark speculative decoding.
+Halo across mandatory OdinLink or Mellanox RDMA (mlx5 RoCE v2 or native
+InfiniBand), including ordinary greedy decode and opt-in DSpark speculative
+decoding.
 
 Source work belongs in Git branches and worktrees. Research evidence belongs in
 the sibling canonical archive selected by `DS4_RESEARCH_ROOT`; it must not be

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# DS4 Strix Halo TP over OdinLink or RoCE v2
+# DS4 Strix Halo TP over OdinLink, RoCE v2, or InfiniBand
 
 Tensor-parallel **DeepSeek V4 Flash 0731** inference across two AMD Strix Halo
 APUs. This fork runs the 153.32 GiB Q4_K model over consumer USB4/TB5 with
-OdinLink GPU RDMA, or over a standard Mellanox RoCE v2 link.
+OdinLink GPU RDMA, over a Mellanox RoCE v2 link, or over a directly connected
+native Mellanox InfiniBand cable (ConnectX-3, `mlx4`).
 
 - **2 × Ryzen AI MAX+ 395 / Radeon 8060S**
 - **2 × 128 GB installed RAM; 96 GiB ROCm aperture per node**
@@ -13,7 +14,7 @@ OdinLink GPU RDMA, or over a standard Mellanox RoCE v2 link.
 ```text
  Ryzen AI MAX+ 395          RDMA link          Ryzen AI MAX+ 395
    Radeon 8060S       <================>          Radeon 8060S
-     TP rank 0       OdinLink or RoCE v2           TP rank 1
+      TP rank 0    OdinLink, RoCE v2, or IB          TP rank 1
 ```
 
 ## Performance (DeepSeek V4 Flash 0731)
@@ -114,7 +115,8 @@ Run one fixed Q4_K benchmark:
   /absolute/path/DeepSeek-V4-Flash-Q4_K-0731.gguf
 ```
 
-Select `DS4_BENCH_RDMA_PROFILE=roce-v2` in `bench.env.local` for Mellanox.
+Select `DS4_BENCH_RDMA_PROFILE=roce-v2` in `bench.env.local` for Mellanox
+RoCE v2, or `ib-mlx4` for native Mellanox InfiniBand.
 Use distinct tags (`q4-r1`, `q4-r2`, `q4-r3`) and report the median. Candidate
 fingerprints and the combined pre-main test belong to the
 local validation archive at
@@ -186,6 +188,47 @@ in `bench.env.local`, set `DS4_BENCH_RDMA_PROFILE=roce-v2`, and run the same
 benchmark command. Reference hardware details and the registration pitfall are
 documented locally under `$DS4_RESEARCH_ROOT/reports/roce-v2-2026-08-14/`.
 
+## Mellanox InfiniBand (ConnectX-3, mlx4)
+
+A directly connected native InfiniBand cable (no RoCE GID-type or 9,000-byte
+MTU configuration) uses the generic verbs path: RC queue pairs, 16 KiB decode
+framing, and a single full-slab MR. RC is required because the exchanges are
+full-duplex post-recv/post-send: a UC SEND that reaches the peer before its
+RECV WR is armed is dropped silently (no RNR retry) and hangs the round,
+while RC retransmits on RNR. Install the same system verbs on both nodes and
+keep the OdinLink provider variables unset:
+
+```sh
+sudo apt install rdma-core ibverbs-utils opensm
+unset DS4_TP_VERBS_LIB ODL_VERBS_WC_STREAM_COPY DS4_TP_ODINLINK_BATCH_ASYNC
+```
+
+Run a subnet manager on one node so both directly connected ports receive
+LIDs, and give the InfiniBand network devices addresses on one subnet for the
+TCP control plane:
+
+```sh
+sudo opensm
+sudo ip addr replace <node-address>/24 dev <ib-netdev>
+rdma link show    # both ports must be ACTIVE with LIDs 1 and 2
+```
+
+Prove that the device can register DS4's mapped communication slab. GID 0 is
+the canonical native-IB GID and is also selected automatically when no
+IPv4-mapped GID exists:
+
+```sh
+ibv_devinfo -d <ib-device>
+make tests/roce_v2_mr_probe
+./tests/roce_v2_mr_probe <ib-device>
+```
+
+In `bench.env.local`, set `DS4_BENCH_RDMA_PROFILE=ib-mlx4`, the coordinator's
+InfiniBand interface address, both device names from `ibv_devinfo -l`
+(udev may name them like `ibp195s0`), and `DS4_RDMA_GID_INDEX=0`; then run the
+same benchmark command. For a manual two-node run, pass
+`--transport rdma --rdma-device <ib-device> --rdma-gid-index 0` on both ranks.
+
 ## Production server
 
 The included 256K profile starts both independent model loads together, keeps
@@ -235,7 +278,8 @@ git pull --ff-only origin main
 
 ## When to use upstream DS4
 
-This fork is for **dual-Strix-Halo TP=2 over OdinLink or RoCE v2**. For general
+This fork is for **dual-Strix-Halo TP=2 over OdinLink, RoCE v2, or
+InfiniBand**. For general
 DS4 usage—including model downloads, single-node inference, Metal, CUDA,
 multi-GPU CUDA, SSD streaming, pipeline parallelism, the server, and the coding
 agent—use the canonical [antirez/ds4](https://github.com/antirez/ds4) README and

--- a/bench.env.example
+++ b/bench.env.example
@@ -24,6 +24,16 @@
 # : "${DS4_PEER_RDMA_DEVICE:=mlx5_1}"
 # : "${DS4_RDMA_GID_INDEX:=3}"
 
+# For native Mellanox InfiniBand (ConnectX-3/mlx4), replace the active
+# OdinLink values above with these settings. A subnet manager (opensm) must
+# run on one node so both ports have LIDs; device names come from
+# `ibv_devinfo -l` and may be distro-renamed by udev (e.g. ibp195s0).
+# : "${DS4_BENCH_RDMA_PROFILE:=ib-mlx4}"
+# : "${DS4_COORDINATOR_ADDR:=192.168.100.1}"
+# : "${DS4_LOCAL_RDMA_DEVICE:=ibp195s0}"
+# : "${DS4_PEER_RDMA_DEVICE:=ibp195s0}"
+# : "${DS4_RDMA_GID_INDEX:=0}"
+
 # Required only when DS4_BENCH_DSPARK=1. There is deliberately no private or
 # machine-specific drafter default in the public launcher.
 # DS4_BENCH_MTP=/absolute/path/dspark-DeepSeek-V4-Flash-0731-Q8_0.gguf

--- a/deploy/Containerfile.rocm714-rdma
+++ b/deploy/Containerfile.rocm714-rdma
@@ -1,0 +1,10 @@
+FROM docker.io/kyuz0/vllm-rocm-gfx1151@sha256:0b1657cb060dd38b40e85ca4018404cdb43d726432fbfaee89418806713b3820
+
+# Keep userspace verbs and its providers from the same distribution/ABI.
+# Host kernel drivers, sysfs and character devices are supplied at run time.
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      ibverbs-providers=50.0-2ubuntu0.2 \
+      ibverbs-utils=50.0-2ubuntu0.2 \
+      libibverbs1=50.0-2ubuntu0.2 \
+ && rm -rf /var/lib/apt/lists/*

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -62,12 +62,19 @@ be shared. Logs are retained under
 
 Set `RDMA_PROFILE=roce-v2`, `COORDINATOR_RDMA_ADDR=192.168.99.1`,
 `LOCAL_RDMA_DEVICE=mlx5_0`, `PEER_RDMA_DEVICE=mlx5_1`, and
-`RDMA_GID_INDEX=3` for Mellanox. `ODINLINK_ROOT` is then unnecessary.
-RoCE also requires passwordless `sudo` for the launcher: the coordinator runs
-as the system transient service `ds4-tp-coordinator.service` with an actually
-unlimited locked-memory limit. The launcher verifies that effective process
-limit and checks the peer's SSH-session limit before model loading. OdinLink
-retains its transient user service and does not acquire this requirement.
+`RDMA_GID_INDEX=3` for Mellanox RoCE v2. `ODINLINK_ROOT` is then unnecessary.
+For a direct Mellanox InfiniBand cable (ConnectX-3, `mlx4`), set
+`RDMA_PROFILE=ib-mlx4`, the coordinator's InfiniBand interface address as
+`COORDINATOR_RDMA_ADDR`, `LOCAL_RDMA_DEVICE`/`PEER_RDMA_DEVICE` from
+`ibv_devinfo -l` on each node, and `RDMA_GID_INDEX=0`. A subnet manager
+(`opensm`) must run on one node so both ports get LIDs; the launcher checks
+link layer, ACTIVE state, and LID on both sides before model loading.
+Mellanox RDMA (RoCE v2 or InfiniBand) also requires passwordless `sudo` for
+the launcher: the coordinator runs as the system transient service
+`ds4-tp-coordinator.service` with an actually unlimited locked-memory limit.
+The launcher verifies that effective process limit and checks the peer's
+SSH-session limit before model loading. OdinLink retains its transient user
+service and does not acquire this requirement.
 
 Useful commands:
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -76,6 +76,15 @@ The launcher verifies that effective process limit and checks the peer's
 SSH-session limit before model loading. OdinLink retains its transient user
 service and does not acquire this requirement.
 
+Set `DS4_TP_CONTAINER=1` (plus the image, volume, and optional init command)
+to run both ranks in podman containers instead, for hosts where ROCm exists
+only inside a container image. The memlock requirement then moves into the
+container (`--ulimit memlock=-1`), the coordinator runs as a `systemd --user`
+transient unit supervising a foreground `podman run`, the peer worker is a
+detached `--rm` container, and passwordless `sudo` is not required. The
+launcher probes the image, GPU/InfiniBand device access, and the memlock
+limit inside a throwaway container on both nodes before model loading.
+
 Useful commands:
 
 ```sh

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -82,14 +82,43 @@ The launcher verifies that effective process limit and checks the peer's
 SSH-session limit before model loading. OdinLink retains its transient user
 service and does not acquire this requirement.
 
-Set `DS4_TP_CONTAINER=1` (plus the image, volume, and optional init command)
+Set `DS4_TP_CONTAINER=1` (plus the image reference, content-addressed image ID, dedicated
+read-only artifact volume, separate writable runtime volume, and optional init command)
 to run both ranks in podman containers instead, for hosts where ROCm exists
 only inside a container image. The memlock requirement then moves into the
 container (`--ulimit memlock=-1`), the coordinator runs as a `systemd --user`
 transient unit supervising a foreground `podman run`, the peer worker is a
 detached `--rm` container, and passwordless `sudo` is not required. The
 launcher probes the image, GPU/InfiniBand device access, and the memlock
-limit inside a throwaway container on both nodes before model loading.
+limit inside a throwaway container on both nodes before model loading. It
+refuses mutable tags, mismatched image IDs, broad/home/credential directories,
+and missing peer volumes. Container mode is a dedicated-host, administrator-
+only trust boundary: host networking/IPC and `/dev/kfd` remain necessary for
+this TP/RDMA design.
+
+Before enabling it, install the exact same image on both nodes and record its
+content identity:
+
+```sh
+podman build --pull=never -f deploy/Containerfile.rocm714-rdma \
+  -t localhost/ds4-rocm714-rdma:local .
+podman image inspect --format '{{.Id}} {{.Digest}} {{join .RepoDigests " "}}' \
+  localhost/ds4-rocm714-rdma:local
+```
+
+The supplied Containerfile pins the ROCm 7.14/gfx1151 base-image digest and
+installs matching, version-pinned Ubuntu `libibverbs` providers and inspection
+utilities. Do not bind-mount provider libraries from the host: a host/container
+ABI mismatch makes verbs discovery fail and may not be caught until after the
+large model has loaded.
+
+Set `DS4_TP_CONTAINER_IMAGE` to that local tag (or a registry digest) and
+`DS4_TP_CONTAINER_IMAGE_ID` to the 64-hex `.Id` returned on both nodes. Do not
+use a tag that was built independently on each machine. When an image is
+transferred with `podman save|load`, the manifest digest may be rewritten; the
+content-addressed image ID is therefore the mandatory parity pin. Use a dedicated pair
+of directories such as `/srv/ds4-container` and `/srv/ds4-container-runtime`;
+the launcher mounts artifacts read-only and runtime state separately.
 
 Useful commands:
 

--- a/deploy/config.env.example
+++ b/deploy/config.env.example
@@ -28,6 +28,24 @@ RDMA_PROFILE=odinlink
 # PEER_RDMA_DEVICE=ibp195s0
 # RDMA_GID_INDEX=0
 
+# Optional containerized deployment for Mellanox profiles when ROCm exists
+# only inside a container image. The coordinator stays a systemd --user
+# transient unit supervising a local container; the peer worker is a detached
+# container. No passwordless sudo is needed. The image must provide the
+# gfx1151 ROCm toolchain; the launcher sets host networking, the
+# /dev/dri, /dev/kfd, and /dev/infiniband devices, and an unlimited memlock
+# ulimit itself.
+# DS4_TP_CONTAINER=1
+# DS4_TP_CONTAINER_IMAGE=localhost/ds4-vllm-patched:local
+# Host directory mounted at the same path inside the containers. It must
+# contain the repository, the model, and the log directory under the
+# research root on each node.
+# DS4_TP_CONTAINER_VOLUME=/home/user
+# Optional shell commands run inside the container before the binary, e.g.
+# to repair a broken ROCm library in the image. Quote values that contain
+# spaces: this file is sourced by the launcher.
+# DS4_TP_CONTAINER_INIT="install -m755 /opt/venv/lib/python3.12/site-packages/_rocm_sdk_core/lib/libhsa-runtime64.so.1 /opt/rocm/lib/libhsa-runtime64.so.1.21.0"
+
 # Both independent filesystems must contain this repository at this path.
 PEER_REPO=/absolute/path/ds4-strix-halo-tp-odinlink
 ODINLINK_ROOT=/absolute/path/OdinLink-Five

--- a/deploy/config.env.example
+++ b/deploy/config.env.example
@@ -15,13 +15,18 @@ PEER_MGMT=user@peer-management-address
 PEER_HOST_KEY_ALIAS=peer-rdma-host-key-alias
 COORDINATOR_RDMA_ADDR=10.4.0.1
 
-# Transport profile: odinlink (default) or roce-v2. For the reference
-# ConnectX-4 Lx pair, use the values below and set COORDINATOR_RDMA_ADDR to
-# 192.168.99.1.
+# Transport profile: odinlink (default), roce-v2, or ib-mlx4. For the
+# reference ConnectX-4 Lx pair, use the RoCE v2 values below and set
+# COORDINATOR_RDMA_ADDR to 192.168.99.1. For a direct ConnectX-3 (mlx4)
+# InfiniBand cable, use the ib-mlx4 values; a subnet manager (opensm) must
+# run on one node, and device names come from `ibv_devinfo -l`.
 RDMA_PROFILE=odinlink
 # LOCAL_RDMA_DEVICE=mlx5_0
 # PEER_RDMA_DEVICE=mlx5_1
 # RDMA_GID_INDEX=3
+# LOCAL_RDMA_DEVICE=ibp195s0
+# PEER_RDMA_DEVICE=ibp195s0
+# RDMA_GID_INDEX=0
 
 # Both independent filesystems must contain this repository at this path.
 PEER_REPO=/absolute/path/ds4-strix-halo-tp-odinlink

--- a/deploy/config.env.example
+++ b/deploy/config.env.example
@@ -29,21 +29,23 @@ RDMA_PROFILE=odinlink
 # RDMA_GID_INDEX=0
 
 # Optional containerized deployment for Mellanox profiles when ROCm exists
-# only inside a container image. The coordinator stays a systemd --user
-# transient unit supervising a local container; the peer worker is a detached
-# container. No passwordless sudo is needed. The image must provide the
-# gfx1151 ROCm toolchain; the launcher sets host networking, the
-# /dev/dri, /dev/kfd, and /dev/infiniband devices, and an unlimited memlock
-# ulimit itself.
+# only inside a container image. This is rootless but deliberately high-trust:
+# TP/RDMA needs host networking/IPC and /dev/kfd/RDMA access. Use a dedicated
+# artifact directory, never a home directory or a broad host tree. The image
+# must have the same content-addressed image ID on both independent filesystems.
 # DS4_TP_CONTAINER=1
-# DS4_TP_CONTAINER_IMAGE=localhost/ds4-vllm-patched:local
-# Host directory mounted at the same path inside the containers. It must
-# contain the repository, the model, and the log directory under the
-# research root on each node.
-# DS4_TP_CONTAINER_VOLUME=/home/user
+# A local tag is acceptable only because the image ID below is mandatory and
+# compared on both nodes. A registry digest may also be used when available.
+# DS4_TP_CONTAINER_IMAGE=localhost/ds4-vllm-patched:rocm7.14
+# DS4_TP_CONTAINER_IMAGE_ID=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+# Read-only artifact directory mounted at the same path inside both containers.
+# DS4_TP_CONTAINER_VOLUME=/srv/ds4-container
+# Required separate writable directory for logs/runtime state.
+# DS4_TP_CONTAINER_WRITABLE_VOLUME=/srv/ds4-container-runtime
 # Optional shell commands run inside the container before the binary, e.g.
 # to repair a broken ROCm library in the image. Quote values that contain
-# spaces: this file is sourced by the launcher.
+# spaces. This is administrator-only code executed inside a device-enabled
+# container; leave unset unless absolutely required.
 # DS4_TP_CONTAINER_INIT="install -m755 /opt/venv/lib/python3.12/site-packages/_rocm_sdk_core/lib/libhsa-runtime64.so.1 /opt/rocm/lib/libhsa-runtime64.so.1.21.0"
 
 # Both independent filesystems must contain this repository at this path.

--- a/deploy/ds4-tp-caddy.sh
+++ b/deploy/ds4-tp-caddy.sh
@@ -73,6 +73,11 @@ CONTAINER=${DS4_TP_CONTAINER:-0}
 if [[ $CONTAINER == 1 ]]; then
   : "${DS4_TP_CONTAINER_IMAGE:?DS4_TP_CONTAINER_IMAGE is required when DS4_TP_CONTAINER=1}"
   : "${DS4_TP_CONTAINER_VOLUME:?DS4_TP_CONTAINER_VOLUME is required when DS4_TP_CONTAINER=1}"
+  : "${DS4_TP_CONTAINER_IMAGE_ID:?DS4_TP_CONTAINER_IMAGE_ID is required when DS4_TP_CONTAINER=1}"
+  : "${DS4_TP_CONTAINER_WRITABLE_VOLUME:?DS4_TP_CONTAINER_WRITABLE_VOLUME is required when DS4_TP_CONTAINER=1}"
+  [[ $DS4_TP_CONTAINER_IMAGE_ID =~ ^[0-9a-fA-F]{64}$ ]] || {
+    echo "error: DS4_TP_CONTAINER_IMAGE_ID must be the 64-hex content ID" >&2; exit 2;
+  }
   CONTAINER_VOLUME=$DS4_TP_CONTAINER_VOLUME
   [[ $RDMA_PROFILE != odinlink ]] || {
     echo "error: DS4_TP_CONTAINER=1 supports only the Mellanox profiles" >&2
@@ -80,19 +85,63 @@ if [[ $CONTAINER == 1 ]]; then
   }
   CONTAINER_INIT=${DS4_TP_CONTAINER_INIT:-}
   CONTAINER_WORKER=ds4-tp-worker
+  # A container volume must be a dedicated directory, not a home directory
+  # or a broad host tree. It may contain only the deployment artifacts.
+  CONTAINER_VOLUME=$(realpath -e -- "$CONTAINER_VOLUME" 2>/dev/null) || {
+    echo "error: DS4_TP_CONTAINER_VOLUME must already exist" >&2; exit 2;
+  }
+  [[ $CONTAINER_VOLUME != / && $CONTAINER_VOLUME != /home &&
+     $CONTAINER_VOLUME != /root && $CONTAINER_VOLUME != /etc &&
+     $CONTAINER_VOLUME != /var && $CONTAINER_VOLUME != /tmp ]] || {
+    echo "error: DS4_TP_CONTAINER_VOLUME is too broad" >&2; exit 2;
+  }
+  while IFS=: read -r _ _ _ _ _ container_home _; do
+    [[ -n $container_home && $CONTAINER_VOLUME != "$container_home" ]] || {
+      echo "error: container volume must not be a user home directory" >&2; exit 2;
+    }
+  done < <(getent passwd)
+  [[ ! -e $CONTAINER_VOLUME/.ssh && ! -e $CONTAINER_VOLUME/.aws &&
+     ! -e $CONTAINER_VOLUME/.config ]] || {
+    echo "error: container volume contains a credentials directory" >&2; exit 2;
+  }
   # Shared podman spec for both ranks. Host networking carries the TCP
   # control plane and the RDMA verbs; the container's memlock ulimit
   # replaces the system unit's LimitMEMLOCK, so this mode needs no sudo.
   PODMAN_RUN=(podman run --rm
+    --entrypoint /bin/bash
     --network host --ipc host
-    --security-opt label=disable --security-opt unmask=all
+    --cap-drop=all --security-opt no-new-privileges
     --ulimit memlock=-1
-    --device /dev/dri --device /dev/kfd --device /dev/infiniband
-    -v "$CONTAINER_VOLUME:$CONTAINER_VOLUME")
+    --group-add keep-groups
+    --device /dev/kfd)
+  for device in /dev/dri/renderD* /dev/infiniband/uverbs* /dev/infiniband/rdma_cm; do
+    [[ -e $device ]] && PODMAN_RUN+=(--device "$device")
+  done
+  # Kernel verbs devices are not sufficient by themselves: userspace provider
+  # packages must be installed in the image with the image's own ABI. Never
+  # mount host provider libraries into the container. Only discovery sysfs is
+  # supplied by the host, read-only.
+  [[ -d /sys/class/infiniband ]] &&
+    PODMAN_RUN+=(--mount type=bind,src=/sys/class/infiniband,dst=/sys/class/infiniband,ro)
+  PODMAN_RUN+=(-v "$CONTAINER_VOLUME:$CONTAINER_VOLUME:ro")
+  WRITABLE_VOLUME=$(realpath -e -- "$DS4_TP_CONTAINER_WRITABLE_VOLUME" 2>/dev/null) || {
+    echo "error: writable container volume must already exist" >&2; exit 2;
+  }
+  [[ $WRITABLE_VOLUME != "$CONTAINER_VOLUME" ]] || {
+    echo "error: writable volume must be separate from the read-only volume" >&2; exit 2;
+  }
+  PODMAN_RUN+=(-v "$WRITABLE_VOLUME:$WRITABLE_VOLUME:rw")
 fi
 WORKER_PIDFILE=$DS4_PEER_RESEARCH_ROOT/deployment/worker.pid
 LOCAL_LOG=$DS4_RESEARCH_ROOT/deployment/coordinator.log
 WORKER_LOG=$DS4_PEER_RESEARCH_ROOT/deployment/worker.log
+if [[ $CONTAINER == 1 ]]; then
+  # Logs and PID state must remain writable without making model/repository
+  # artifacts writable inside the container.
+  LOCAL_LOG=$WRITABLE_VOLUME/deployment/coordinator.log
+  WORKER_LOG=$WRITABLE_VOLUME/deployment/worker.log
+  WORKER_PIDFILE=$WRITABLE_VOLUME/deployment/worker.pid
+fi
 if [[ $RDMA_PROFILE == odinlink ]]; then
   VERBS_LIB=$ODINLINK_ROOT/build/verbs/libodl_tb5_verbs.so.0.1.0
   ODL_LD_PATH=$ODINLINK_ROOT/build/lib:$ODINLINK_ROOT/build/verbs
@@ -205,31 +254,59 @@ preflight() {
     }
   else
     if [[ $CONTAINER == 1 ]]; then
-      podman image inspect "$DS4_TP_CONTAINER_IMAGE" >/dev/null 2>&1 || {
+      local image_meta expected_image_id
+      image_meta=$(podman image inspect --format '{{.Id}} {{.Digest}} {{join .RepoDigests " "}}' "$DS4_TP_CONTAINER_IMAGE") || {
         echo "error: local container image $DS4_TP_CONTAINER_IMAGE is missing" >&2
         exit 1
       }
-      if ! "${PODMAN_RUN[@]}" "$DS4_TP_CONTAINER_IMAGE" bash -c \
-          '[[ $(ulimit -l) == unlimited ]] && [[ -c /dev/kfd && -d /dev/dri && -e /dev/infiniband/uverbs0 ]]'; then
-        echo "error: local container cannot see GPU/InfiniBand devices with unlimited memlock" >&2
+      expected_image_id=${image_meta%% *}
+      [[ ${expected_image_id,,} == ${DS4_TP_CONTAINER_IMAGE_ID,,} ]] || {
+        echo "error: local container image ID does not match DS4_TP_CONTAINER_IMAGE_ID" >&2
+        exit 1
+      }
+      if ! "${PODMAN_RUN[@]}" "$DS4_TP_CONTAINER_IMAGE" -c \
+          '[[ $(ulimit -l) == unlimited ]] && [[ -c /dev/kfd && -d /dev/dri && -e /dev/infiniband/uverbs0 ]] && command -v ibv_devinfo >/dev/null && ibv_devinfo -d "$1" -l >/dev/null && "$2/ds4" --help >/dev/null' \
+          _ "$LOCAL_RDMA_DEVICE" "$REPO"; then
+        echo "error: local container cannot execute DS4 or discover GPU/InfiniBand with unlimited memlock" >&2
         exit 1
       fi
       if [[ -n $CONTAINER_INIT ]]; then
-        "${PODMAN_RUN[@]}" "$DS4_TP_CONTAINER_IMAGE" bash -c "set -e; $CONTAINER_INIT; true" || {
+        "${PODMAN_RUN[@]}" "$DS4_TP_CONTAINER_IMAGE" -c "set -e; $CONTAINER_INIT; true" || {
           echo "error: DS4_TP_CONTAINER_INIT failed in a fresh local container" >&2
           exit 1
         }
       fi
       local podman_q
       printf -v podman_q '%q ' "${PODMAN_RUN[@]}"
-      "${SSH[@]}" "$podman_q '$DS4_TP_CONTAINER_IMAGE' bash -c '[[ \$(ulimit -l) == unlimited ]] && [[ -c /dev/kfd && -d /dev/dri && -e /dev/infiniband/uverbs0 ]]'" || {
-        echo "error: peer container image or GPU/InfiniBand access with unlimited memlock is unavailable" >&2
+      local peer_device_q peer_repo_q
+      printf -v peer_device_q '%q' "$PEER_RDMA_DEVICE"
+      printf -v peer_repo_q '%q' "$PEER_REPO"
+      "${SSH[@]}" "$podman_q '$DS4_TP_CONTAINER_IMAGE' -c '[[ \$(ulimit -l) == unlimited ]] && [[ -c /dev/kfd && -d /dev/dri && -e /dev/infiniband/uverbs0 ]] && command -v ibv_devinfo >/dev/null && ibv_devinfo -d \"\$1\" -l >/dev/null && \"\$2/ds4\" --help >/dev/null' _ $peer_device_q $peer_repo_q" || {
+        echo "error: peer container cannot execute DS4 or discover GPU/InfiniBand with unlimited memlock" >&2
+        exit 1
+      }
+      local peer_image_id
+      peer_image_id=$("${SSH[@]}" "podman image inspect --format '{{.Id}}' '$DS4_TP_CONTAINER_IMAGE'") || {
+        echo "error: peer container image cannot be inspected" >&2; exit 1;
+      }
+      [[ ${peer_image_id,,} == ${DS4_TP_CONTAINER_IMAGE_ID,,} ]] || {
+        echo "error: peer container image ID differs from local pinned image" >&2
+        exit 1
+      }
+      "${SSH[@]}" "test -d '$DS4_TP_CONTAINER_VOLUME' -a -d '$DS4_TP_CONTAINER_WRITABLE_VOLUME'" || {
+        echo "error: peer container volumes are missing" >&2; exit 1;
+      }
+      local peer_volume_q peer_writable_q
+      printf -v peer_volume_q '%q' "$DS4_TP_CONTAINER_VOLUME"
+      printf -v peer_writable_q '%q' "$DS4_TP_CONTAINER_WRITABLE_VOLUME"
+      "${SSH[@]}" "v=\$(realpath -e -- $peer_volume_q) && w=\$(realpath -e -- $peer_writable_q) && [[ \$v != / && \$v != /home && \$v != /root && \$v != /etc && \$v != /var && \$v != /tmp && \$v != \$w ]] && (getent passwd | awk -F: -v p=\"\$v\" '\$6 == p { bad=1 } END { exit bad }') && [[ ! -e \"\$v/.ssh\" && ! -e \"\$v/.aws\" && ! -e \"\$v/.config\" ]]" || {
+        echo "error: peer container volumes are broad, credential-bearing, or identical" >&2
         exit 1
       }
       if [[ -n $CONTAINER_INIT ]]; then
         local peer_init_q
         printf -v peer_init_q '%q' "set -e; $CONTAINER_INIT; true"
-        "${SSH[@]}" "$podman_q '$DS4_TP_CONTAINER_IMAGE' bash -c $peer_init_q" || {
+        "${SSH[@]}" "$podman_q '$DS4_TP_CONTAINER_IMAGE' -c $peer_init_q" || {
           echo "error: DS4_TP_CONTAINER_INIT failed in a fresh peer container" >&2
           exit 1
         }
@@ -276,6 +353,11 @@ preflight() {
   local_bin=$(sha256sum "$REPO/ds4" | awk '{print $1}')
   peer_bin=$("${SSH[@]}" "sha256sum '$PEER_REPO/ds4'" | awk '{print $1}')
   [[ $local_bin == "$peer_bin" ]] || { echo "error: node binaries differ" >&2; exit 1; }
+  local peer_server_hash
+  peer_server_hash=$("${SSH[@]}" "sha256sum '$PEER_REPO/ds4-server'" | awk '{print $1}')
+  [[ ${peer_server_hash,,} == ${DS4_SERVER_SHA256,,} ]] || {
+    echo "error: peer ds4-server does not match DS4_SERVER_SHA256" >&2; exit 1;
+  }
   [[ $(sample_fingerprint "$MODEL") == "$(remote_fingerprint "$MODEL")" ]] || {
     echo "error: target-model fingerprints differ" >&2; exit 1;
   }
@@ -292,6 +374,10 @@ preflight() {
   mkdir -p "$RUNTIME" "$(dirname -- "$LOCAL_LOG")"
   printf -v peer_research_deploy_q '%q' "$DS4_PEER_RESEARCH_ROOT/deployment"
   "${SSH[@]}" "mkdir -p $peer_research_deploy_q"
+  if [[ $CONTAINER == 1 ]]; then
+    printf -v writable_deploy_q '%q' "$WRITABLE_VOLUME/deployment"
+    "${SSH[@]}" "mkdir -p $writable_deploy_q"
+  fi
 }
 
 start() {
@@ -416,7 +502,7 @@ start() {
     printf -v inner_q '%q' "$worker_inner"
     # Detached worker container; the pid file stores the container id and
     # stdout lands in the same host log file as in host mode.
-    "${SSH[@]}" "$podman_q -d --name $CONTAINER_WORKER -w $repo_q '$DS4_TP_CONTAINER_IMAGE' bash -c $inner_q >$pid_q"
+    "${SSH[@]}" "$podman_q -d --name $CONTAINER_WORKER -w $repo_q '$DS4_TP_CONTAINER_IMAGE' -c $inner_q >$pid_q"
   else
     # Keep the background operator scoped to ds4 itself. With `cd && cmd &`,
     # POSIX shells background the whole AND-list and `$!` names a wrapper shell.
@@ -441,7 +527,7 @@ start() {
       --property="StandardError=append:$LOCAL_LOG" \
       "${PODMAN_RUN[@]}" --name "$COORD_UNIT" -w "$REPO" \
         "$DS4_TP_CONTAINER_IMAGE" \
-        bash -c "$coordinator_inner" >/dev/null
+        -c "$coordinator_inner" >/dev/null
   elif [[ $RDMA_PROFILE != odinlink ]]; then
     # Mellanox RDMA registration needs more than the user manager's inherited
     # 8 MiB hard memlock limit. A system transient unit can genuinely raise
@@ -465,19 +551,21 @@ start() {
   coord_pid=$(coord_main_pid)
   [[ $coord_pid =~ ^[1-9][0-9]*$ ]] || {
     echo "error: coordinator service failed to start" >&2
+    "${SSH[@]}" "podman stop -t 10 '$CONTAINER_WORKER' >/dev/null 2>&1 || true"
     return 1
   }
   if [[ $CONTAINER == 1 ]]; then
     local container_memlock
     container_memlock=
     for _ in $(seq 1 50); do
-      container_memlock=$(podman exec "$COORD_UNIT" ulimit -l 2>/dev/null || true)
+      container_memlock=$(podman exec "$COORD_UNIT" /bin/bash -c 'ulimit -l' 2>/dev/null || true)
       [[ $container_memlock == unlimited ]] && break
       sleep 0.2
     done
     [[ $container_memlock == unlimited ]] || {
       echo "error: coordinator container memlock is ${container_memlock:-unavailable}, expected unlimited" >&2
       coord_stop_service
+      "${SSH[@]}" "podman stop -t 10 '$CONTAINER_WORKER' >/dev/null 2>&1 || true"
       return 1
     }
   elif [[ $RDMA_PROFILE != odinlink ]]; then
@@ -550,10 +638,11 @@ logs() {
 }
 
 case ${1:-status} in
+  preflight) preflight ;;
   start) start ;;
   stop) stop ;;
   restart) stop; start ;;
   status) status ;;
   logs) logs ;;
-  *) echo "usage: $0 {start|stop|restart|status|logs}" >&2; exit 2 ;;
+  *) echo "usage: $0 {preflight|start|stop|restart|status|logs}" >&2; exit 2 ;;
 esac

--- a/deploy/ds4-tp-caddy.sh
+++ b/deploy/ds4-tp-caddy.sh
@@ -65,6 +65,31 @@ PEER_HOST_KEY_ALIAS=${PEER_HOST_KEY_ALIAS:-$PEER_MGMT}
 RUNTIME=$SCRIPT_DIR/runtime
 LOCAL_PIDFILE=$RUNTIME/coordinator.pid
 COORD_UNIT=${COORD_UNIT:-ds4-tp-coordinator}
+CONTAINER=${DS4_TP_CONTAINER:-0}
+[[ $CONTAINER == 0 || $CONTAINER == 1 ]] || {
+  echo "error: DS4_TP_CONTAINER must be 0 or 1" >&2
+  exit 2
+}
+if [[ $CONTAINER == 1 ]]; then
+  : "${DS4_TP_CONTAINER_IMAGE:?DS4_TP_CONTAINER_IMAGE is required when DS4_TP_CONTAINER=1}"
+  : "${DS4_TP_CONTAINER_VOLUME:?DS4_TP_CONTAINER_VOLUME is required when DS4_TP_CONTAINER=1}"
+  CONTAINER_VOLUME=$DS4_TP_CONTAINER_VOLUME
+  [[ $RDMA_PROFILE != odinlink ]] || {
+    echo "error: DS4_TP_CONTAINER=1 supports only the Mellanox profiles" >&2
+    exit 2
+  }
+  CONTAINER_INIT=${DS4_TP_CONTAINER_INIT:-}
+  CONTAINER_WORKER=ds4-tp-worker
+  # Shared podman spec for both ranks. Host networking carries the TCP
+  # control plane and the RDMA verbs; the container's memlock ulimit
+  # replaces the system unit's LimitMEMLOCK, so this mode needs no sudo.
+  PODMAN_RUN=(podman run --rm
+    --network host --ipc host
+    --security-opt label=disable --security-opt unmask=all
+    --ulimit memlock=-1
+    --device /dev/dri --device /dev/kfd --device /dev/infiniband
+    -v "$CONTAINER_VOLUME:$CONTAINER_VOLUME")
+fi
 WORKER_PIDFILE=$DS4_PEER_RESEARCH_ROOT/deployment/worker.pid
 LOCAL_LOG=$DS4_RESEARCH_ROOT/deployment/coordinator.log
 WORKER_LOG=$DS4_PEER_RESEARCH_ROOT/deployment/worker.log
@@ -79,9 +104,9 @@ is_uint() { [[ $1 =~ ^[1-9][0-9]*$ ]]; }
 is_uint "$CONTEXT" && is_uint "$PREFILL_CHUNK" && is_uint "$EXPERT_SPLIT" &&
   is_uint "$TP_TIMEOUT_SEC" && is_uint "$TP_PORT" &&
   is_uint "$API_PORT" || {
-    echo "error: context, chunk, expert split, TP timeout, and ports must be positive integers" >&2
-    exit 2
-  }
+  echo "error: context, chunk, expert split, TP timeout, and ports must be positive integers" >&2
+  exit 2
+}
 (( EXPERT_SPLIT < 256 )) || { echo "error: expert split must be in 1..255" >&2; exit 2; }
 [[ $DSPARK == 0 || $DSPARK == 1 ]] || { echo "error: DSPARK must be 0 or 1" >&2; exit 2; }
 [[ $PREFILL_FFN_WAVEFRONT == 0 || $PREFILL_FFN_WAVEFRONT == 1 ]] || {
@@ -133,7 +158,7 @@ pid_matches() {
 }
 
 coord_is_active() {
-  if [[ $RDMA_PROFILE != odinlink ]]; then
+  if [[ $RDMA_PROFILE != odinlink && $CONTAINER == 0 ]]; then
     sudo -n systemctl is-active --quiet "$COORD_UNIT.service"
   else
     systemctl --user is-active --quiet "$COORD_UNIT.service"
@@ -141,7 +166,7 @@ coord_is_active() {
 }
 
 coord_main_pid() {
-  if [[ $RDMA_PROFILE != odinlink ]]; then
+  if [[ $RDMA_PROFILE != odinlink && $CONTAINER == 0 ]]; then
     sudo -n systemctl show -p MainPID --value "$COORD_UNIT.service"
   else
     systemctl --user show -p MainPID --value "$COORD_UNIT.service"
@@ -149,7 +174,7 @@ coord_main_pid() {
 }
 
 coord_stop_service() {
-  if [[ $RDMA_PROFILE != odinlink ]]; then
+  if [[ $RDMA_PROFILE != odinlink && $CONTAINER == 0 ]]; then
     sudo -n systemctl stop "$COORD_UNIT.service"
   else
     systemctl --user stop "$COORD_UNIT.service"
@@ -179,10 +204,42 @@ preflight() {
       echo "error: peer binary, model, OdinLink device, or provider is missing" >&2; exit 1;
     }
   else
-    sudo -n true || {
-      echo "error: passwordless sudo is required to give the RDMA service unlimited memlock" >&2
-      exit 1
-    }
+    if [[ $CONTAINER == 1 ]]; then
+      podman image inspect "$DS4_TP_CONTAINER_IMAGE" >/dev/null 2>&1 || {
+        echo "error: local container image $DS4_TP_CONTAINER_IMAGE is missing" >&2
+        exit 1
+      }
+      if ! "${PODMAN_RUN[@]}" "$DS4_TP_CONTAINER_IMAGE" bash -c \
+          '[[ $(ulimit -l) == unlimited ]] && [[ -c /dev/kfd && -d /dev/dri && -e /dev/infiniband/uverbs0 ]]'; then
+        echo "error: local container cannot see GPU/InfiniBand devices with unlimited memlock" >&2
+        exit 1
+      fi
+      if [[ -n $CONTAINER_INIT ]]; then
+        "${PODMAN_RUN[@]}" "$DS4_TP_CONTAINER_IMAGE" bash -c "set -e; $CONTAINER_INIT; true" || {
+          echo "error: DS4_TP_CONTAINER_INIT failed in a fresh local container" >&2
+          exit 1
+        }
+      fi
+      local podman_q
+      printf -v podman_q '%q ' "${PODMAN_RUN[@]}"
+      "${SSH[@]}" "$podman_q '$DS4_TP_CONTAINER_IMAGE' bash -c '[[ \$(ulimit -l) == unlimited ]] && [[ -c /dev/kfd && -d /dev/dri && -e /dev/infiniband/uverbs0 ]]'" || {
+        echo "error: peer container image or GPU/InfiniBand access with unlimited memlock is unavailable" >&2
+        exit 1
+      }
+      if [[ -n $CONTAINER_INIT ]]; then
+        local peer_init_q
+        printf -v peer_init_q '%q' "set -e; $CONTAINER_INIT; true"
+        "${SSH[@]}" "$podman_q '$DS4_TP_CONTAINER_IMAGE' bash -c $peer_init_q" || {
+          echo "error: DS4_TP_CONTAINER_INIT failed in a fresh peer container" >&2
+          exit 1
+        }
+      fi
+    else
+      sudo -n true || {
+        echo "error: passwordless sudo is required to give the RDMA service unlimited memlock" >&2
+        exit 1
+      }
+    fi
     if [[ $RDMA_PROFILE == roce-v2 ]]; then
       grep -qx 'RoCE v2' \
         "/sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/gid_attrs/types/$RDMA_GID_INDEX" || {
@@ -205,12 +262,14 @@ preflight() {
         echo "error: peer binary/model or native-InfiniBand port is unavailable" >&2; exit 1;
       }
     fi
-    local peer_memlock
-    peer_memlock=$("${SSH[@]}" 'ulimit -l')
-    if [[ $peer_memlock != unlimited ]] &&
-       { [[ ! $peer_memlock =~ ^[0-9]+$ ]] || (( peer_memlock < 131072 )); }; then
-      echo "error: peer locked-memory limit is ${peer_memlock} KiB; RDMA deployment requires at least 128 MiB" >&2
-      exit 1
+    if [[ $CONTAINER == 0 ]]; then
+      local peer_memlock
+      peer_memlock=$("${SSH[@]}" 'ulimit -l')
+      if [[ $peer_memlock != unlimited ]] &&
+         { [[ ! $peer_memlock =~ ^[0-9]+$ ]] || (( peer_memlock < 131072 )); }; then
+        echo "error: peer locked-memory limit is ${peer_memlock} KiB; RDMA deployment requires at least 128 MiB" >&2
+        exit 1
+      fi
     fi
   fi
   local local_bin peer_bin
@@ -246,9 +305,15 @@ start() {
   ss -ltnH "sport = :$API_PORT" | grep -q . && {
     echo "error: API port $API_PORT is already listening" >&2; exit 1;
   }
-  "${SSH[@]}" "if test -r '$WORKER_PIDFILE'; then p=\$(cat '$WORKER_PIDFILE'); case \"\$p\" in ''|*[!0-9]*) exit 0;; esac; test -r /proc/\$p/cmdline && tr '\\0' ' ' < /proc/\$p/cmdline | grep -Fq -- 'ds4 --role worker' && exit 7; fi; exit 0" || {
-    rc=$?; [[ $rc == 7 ]] && echo "error: owned worker is already running" >&2; exit "$rc";
-  }
+  if [[ $CONTAINER == 1 ]]; then
+    local running
+    running=$("${SSH[@]}" "podman ps -q --filter name=$CONTAINER_WORKER --filter status=running")
+    [[ -n $running ]] && { echo "error: owned worker is already running" >&2; exit 1; }
+  else
+    "${SSH[@]}" "if test -r '$WORKER_PIDFILE'; then p=\$(cat '$WORKER_PIDFILE'); case \"\$p\" in ''|*[!0-9]*) exit 0;; esac; test -r /proc/\$p/cmdline && tr '\\0' ' ' < /proc/\$p/cmdline | grep -Fq -- 'ds4 --role worker' && exit 7; fi; exit 0" || {
+      rc=$?; [[ $rc == 7 ]] && echo "error: owned worker is already running" >&2; exit "$rc";
+    }
+  fi
 
   local -a common worker coordinator decode_env support_args
   local -a worker_rdma_args coordinator_rdma_args
@@ -340,15 +405,48 @@ start() {
   printf -v repo_q '%q' "$PEER_REPO"
   printf -v log_q '%q' "$WORKER_LOG"
   printf -v pid_q '%q' "$WORKER_PIDFILE"
-  # Keep the background operator scoped to ds4 itself. With `cd && cmd &`,
-  # POSIX shells background the whole AND-list and `$!` names a wrapper shell.
-  "${SSH[@]}" "cd $repo_q || exit 1; nohup setsid $worker_q >$log_q 2>&1 </dev/null & p=\$!; echo \$p >$pid_q"
+  if [[ $CONTAINER == 1 ]]; then
+    local worker_inner podman_q inner_q
+    if [[ -n $CONTAINER_INIT ]]; then
+      worker_inner="set -e; $CONTAINER_INIT; exec $worker_q >$log_q 2>&1"
+    else
+      worker_inner="exec $worker_q >$log_q 2>&1"
+    fi
+    printf -v podman_q '%q ' "${PODMAN_RUN[@]}"
+    printf -v inner_q '%q' "$worker_inner"
+    # Detached worker container; the pid file stores the container id and
+    # stdout lands in the same host log file as in host mode.
+    "${SSH[@]}" "$podman_q -d --name $CONTAINER_WORKER -w $repo_q '$DS4_TP_CONTAINER_IMAGE' bash -c $inner_q >$pid_q"
+  else
+    # Keep the background operator scoped to ds4 itself. With `cd && cmd &`,
+    # POSIX shells background the whole AND-list and `$!` names a wrapper shell.
+    "${SSH[@]}" "cd $repo_q || exit 1; nohup setsid $worker_q >$log_q 2>&1 </dev/null & p=\$!; echo \$p >$pid_q"
+  fi
 
-  # Mellanox RDMA registration needs more than the user manager's inherited
-  # 8 MiB hard memlock limit. A system transient unit can genuinely raise that
-  # limit; `systemctl --user show` only reports the requested, not effective,
-  # value.
-  if [[ $RDMA_PROFILE != odinlink ]]; then
+  local coordinator_cmd_q coordinator_inner
+  if [[ $CONTAINER == 1 ]]; then
+    # Container mode: the memlock limit is the container's ulimit, so the
+    # coordinator is a --user transient unit supervising a foreground
+    # podman run (SIGTERM reaches the container through the client).
+    printf -v coordinator_cmd_q '%q ' "${coordinator[@]}"
+    # set -e makes a failed fixup abort the unit before the binary starts.
+    if [[ -n $CONTAINER_INIT ]]; then
+      coordinator_inner="set -e; $CONTAINER_INIT; exec $coordinator_cmd_q"
+    else
+      coordinator_inner="exec $coordinator_cmd_q"
+    fi
+    systemd-run --user --unit="$COORD_UNIT" --collect --service-type=exec \
+      --property="WorkingDirectory=$REPO" \
+      --property="StandardOutput=append:$LOCAL_LOG" \
+      --property="StandardError=append:$LOCAL_LOG" \
+      "${PODMAN_RUN[@]}" --name "$COORD_UNIT" -w "$REPO" \
+        "$DS4_TP_CONTAINER_IMAGE" \
+        bash -c "$coordinator_inner" >/dev/null
+  elif [[ $RDMA_PROFILE != odinlink ]]; then
+    # Mellanox RDMA registration needs more than the user manager's inherited
+    # 8 MiB hard memlock limit. A system transient unit can genuinely raise
+    # that limit; `systemctl --user show` only reports the requested, not
+    # effective, value.
     sudo -n systemd-run --unit="$COORD_UNIT" --collect --service-type=exec \
       --uid="$(id -u)" --gid="$(id -g)" \
       --property="WorkingDirectory=$REPO" \
@@ -369,11 +467,24 @@ start() {
     echo "error: coordinator service failed to start" >&2
     return 1
   }
-  if [[ $RDMA_PROFILE != odinlink ]]; then
+  if [[ $CONTAINER == 1 ]]; then
+    local container_memlock
+    container_memlock=
+    for _ in $(seq 1 50); do
+      container_memlock=$(podman exec "$COORD_UNIT" ulimit -l 2>/dev/null || true)
+      [[ $container_memlock == unlimited ]] && break
+      sleep 0.2
+    done
+    [[ $container_memlock == unlimited ]] || {
+      echo "error: coordinator container memlock is ${container_memlock:-unavailable}, expected unlimited" >&2
+      coord_stop_service
+      return 1
+    }
+  elif [[ $RDMA_PROFILE != odinlink ]]; then
     local effective_memlock
     effective_memlock=$(awk '$1 == "Max" && $2 == "locked" && $3 == "memory" { print $4 }' "/proc/$coord_pid/limits")
     [[ $effective_memlock == unlimited ]] || {
-      echo "error: coordinator effective memlock is $effective_memlock, expected unlimited" >&2
+      echo "error: coordinator effective memlock is ${effective_memlock}, expected unlimited" >&2
       coord_stop_service
       return 1
     }
@@ -390,7 +501,14 @@ stop() {
   elif pid_matches "$LOCAL_PIDFILE" "ds4-server"; then
     pid=$(<"$LOCAL_PIDFILE"); kill -TERM "$pid"; echo "stopped coordinator $pid"
   fi
-  "${SSH[@]}" "if test -r '$WORKER_PIDFILE'; then p=\$(cat '$WORKER_PIDFILE'); case \"\$p\" in ''|*[!0-9]*) exit 0;; esac; if test -r /proc/\$p/cmdline && tr '\\0' ' ' < /proc/\$p/cmdline | grep -Fq -- 'ds4 --role worker'; then kill -TERM \"\$p\"; echo stopped-worker-\$p; fi; fi"
+  if [[ $CONTAINER == 1 ]]; then
+    # Backstop for containers that outlived their unit (e.g. after a crash);
+    # --rm removes them on stop.
+    podman stop -t 60 "$COORD_UNIT" >/dev/null 2>&1 || true
+    "${SSH[@]}" "podman stop -t 60 '$CONTAINER_WORKER' >/dev/null 2>&1 || true"
+  else
+    "${SSH[@]}" "if test -r '$WORKER_PIDFILE'; then p=\$(cat '$WORKER_PIDFILE'); case \"\$p\" in ''|*[!0-9]*) exit 0;; esac; if test -r /proc/\$p/cmdline && tr '\\0' ' ' < /proc/\$p/cmdline | grep -Fq -- 'ds4 --role worker'; then kill -TERM \"\$p\"; echo stopped-worker-\$p; fi; fi"
+  fi
 }
 
 status() {
@@ -404,9 +522,13 @@ status() {
   else
     echo "coordinator: stopped"
   fi
-  worker_state=$("${SSH[@]}" "if test -r '$WORKER_PIDFILE'; then p=\$(cat '$WORKER_PIDFILE'); if test -r /proc/\$p/cmdline && tr '\\0' ' ' < /proc/\$p/cmdline | grep -Fq -- 'ds4 --role worker'; then echo worker-running-pid-\$p; else echo worker-stopped; fi; else echo worker-stopped; fi" 2>/dev/null) || worker_state=worker-unreachable
+  if [[ $CONTAINER == 1 ]]; then
+    worker_state=$("${SSH[@]}" "if test -n \"\$(podman ps -q --filter name=$CONTAINER_WORKER --filter status=running)\"; then echo worker-running-container; else echo worker-stopped; fi" 2>/dev/null) || worker_state=worker-unreachable
+  else
+    worker_state=$("${SSH[@]}" "if test -r '$WORKER_PIDFILE'; then p=\$(cat '$WORKER_PIDFILE'); if test -r /proc/\$p/cmdline && tr '\\0' ' ' < /proc/\$p/cmdline | grep -Fq -- 'ds4 --role worker'; then echo worker-running-pid-\$p; else echo worker-stopped; fi; else echo worker-stopped; fi" 2>/dev/null) || worker_state=worker-unreachable
+  fi
   echo "$worker_state"
-  [[ $worker_state == worker-running-pid-* ]] && worker_ok=1
+  [[ $worker_state == worker-running-* ]] && worker_ok=1
   if curl --silent --show-error --fail --max-time 3 "http://$API_HOST:$API_PORT/health" >/dev/null; then
     api_ok=1
     if ((coord_ok && worker_ok)); then

--- a/deploy/ds4-tp-caddy.sh
+++ b/deploy/ds4-tp-caddy.sh
@@ -32,8 +32,13 @@ case $RDMA_PROFILE in
     PEER_RDMA_DEVICE=${PEER_RDMA_DEVICE:-mlx5_1}
     RDMA_GID_INDEX=${RDMA_GID_INDEX:-3}
     ;;
+  ib-mlx4)
+    LOCAL_RDMA_DEVICE=${LOCAL_RDMA_DEVICE:-ibp195s0}
+    PEER_RDMA_DEVICE=${PEER_RDMA_DEVICE:-ibp195s0}
+    RDMA_GID_INDEX=${RDMA_GID_INDEX:-0}
+    ;;
   *)
-    echo "error: RDMA_PROFILE must be odinlink or roce-v2" >&2
+    echo "error: RDMA_PROFILE must be odinlink, roce-v2, or ib-mlx4" >&2
     exit 2
     ;;
 esac
@@ -128,7 +133,7 @@ pid_matches() {
 }
 
 coord_is_active() {
-  if [[ $RDMA_PROFILE == roce-v2 ]]; then
+  if [[ $RDMA_PROFILE != odinlink ]]; then
     sudo -n systemctl is-active --quiet "$COORD_UNIT.service"
   else
     systemctl --user is-active --quiet "$COORD_UNIT.service"
@@ -136,7 +141,7 @@ coord_is_active() {
 }
 
 coord_main_pid() {
-  if [[ $RDMA_PROFILE == roce-v2 ]]; then
+  if [[ $RDMA_PROFILE != odinlink ]]; then
     sudo -n systemctl show -p MainPID --value "$COORD_UNIT.service"
   else
     systemctl --user show -p MainPID --value "$COORD_UNIT.service"
@@ -144,7 +149,7 @@ coord_main_pid() {
 }
 
 coord_stop_service() {
-  if [[ $RDMA_PROFILE == roce-v2 ]]; then
+  if [[ $RDMA_PROFILE != odinlink ]]; then
     sudo -n systemctl stop "$COORD_UNIT.service"
   else
     systemctl --user stop "$COORD_UNIT.service"
@@ -175,21 +180,36 @@ preflight() {
     }
   else
     sudo -n true || {
-      echo "error: passwordless sudo is required to give the RoCE service unlimited memlock" >&2
+      echo "error: passwordless sudo is required to give the RDMA service unlimited memlock" >&2
       exit 1
     }
-    grep -qx 'RoCE v2' \
-      "/sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/gid_attrs/types/$RDMA_GID_INDEX" || {
-      echo "error: local mlx5 GID is not available as RoCE v2" >&2; exit 1;
-    }
-    "${SSH[@]}" "test -x '$PEER_REPO/ds4' -a -r '$MODEL' && test \"\$(cat '/sys/class/infiniband/$PEER_RDMA_DEVICE/ports/1/gid_attrs/types/$RDMA_GID_INDEX')\" = 'RoCE v2'" || {
-      echo "error: peer binary/model or RoCE v2 GID is unavailable" >&2; exit 1;
-    }
+    if [[ $RDMA_PROFILE == roce-v2 ]]; then
+      grep -qx 'RoCE v2' \
+        "/sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/gid_attrs/types/$RDMA_GID_INDEX" || {
+        echo "error: local mlx5 GID is not available as RoCE v2" >&2; exit 1;
+      }
+      "${SSH[@]}" "test -x '$PEER_REPO/ds4' -a -r '$MODEL' && test \"\$(cat '/sys/class/infiniband/$PEER_RDMA_DEVICE/ports/1/gid_attrs/types/$RDMA_GID_INDEX')\" = 'RoCE v2'" || {
+        echo "error: peer binary/model or RoCE v2 GID is unavailable" >&2; exit 1;
+      }
+    else
+      [[ "$(cat "/sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/link_layer" 2>/dev/null)" == InfiniBand ]] || {
+        echo "error: local $LOCAL_RDMA_DEVICE is not a native InfiniBand port" >&2; exit 1;
+      }
+      [[ "$(cat "/sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/state" 2>/dev/null)" == "4: ACTIVE" ]] || {
+        echo "error: local $LOCAL_RDMA_DEVICE port is not ACTIVE" >&2; exit 1;
+      }
+      [[ "$(cat "/sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/lid" 2>/dev/null)" != 0x0 ]] || {
+        echo "error: local $LOCAL_RDMA_DEVICE has no LID; is a subnet manager running?" >&2; exit 1;
+      }
+      "${SSH[@]}" "test -x '$PEER_REPO/ds4' -a -r '$MODEL' && test \"\$(cat '/sys/class/infiniband/$PEER_RDMA_DEVICE/ports/1/link_layer')\" = InfiniBand && test \"\$(cat '/sys/class/infiniband/$PEER_RDMA_DEVICE/ports/1/state')\" = '4: ACTIVE' && test \"\$(cat '/sys/class/infiniband/$PEER_RDMA_DEVICE/ports/1/lid')\" != '0x0'" || {
+        echo "error: peer binary/model or native-InfiniBand port is unavailable" >&2; exit 1;
+      }
+    fi
     local peer_memlock
     peer_memlock=$("${SSH[@]}" 'ulimit -l')
     if [[ $peer_memlock != unlimited ]] &&
        { [[ ! $peer_memlock =~ ^[0-9]+$ ]] || (( peer_memlock < 131072 )); }; then
-      echo "error: peer locked-memory limit is ${peer_memlock} KiB; RoCE deployment requires at least 128 MiB" >&2
+      echo "error: peer locked-memory limit is ${peer_memlock} KiB; RDMA deployment requires at least 128 MiB" >&2
       exit 1
     fi
   fi
@@ -324,10 +344,11 @@ start() {
   # POSIX shells background the whole AND-list and `$!` names a wrapper shell.
   "${SSH[@]}" "cd $repo_q || exit 1; nohup setsid $worker_q >$log_q 2>&1 </dev/null & p=\$!; echo \$p >$pid_q"
 
-  # RoCE registration needs more than the user manager's inherited 8 MiB hard
-  # memlock limit. A system transient unit can genuinely raise that limit;
-  # `systemctl --user show` only reports the requested, not effective, value.
-  if [[ $RDMA_PROFILE == roce-v2 ]]; then
+  # Mellanox RDMA registration needs more than the user manager's inherited
+  # 8 MiB hard memlock limit. A system transient unit can genuinely raise that
+  # limit; `systemctl --user show` only reports the requested, not effective,
+  # value.
+  if [[ $RDMA_PROFILE != odinlink ]]; then
     sudo -n systemd-run --unit="$COORD_UNIT" --collect --service-type=exec \
       --uid="$(id -u)" --gid="$(id -g)" \
       --property="WorkingDirectory=$REPO" \
@@ -348,7 +369,7 @@ start() {
     echo "error: coordinator service failed to start" >&2
     return 1
   }
-  if [[ $RDMA_PROFILE == roce-v2 ]]; then
+  if [[ $RDMA_PROFILE != odinlink ]]; then
     local effective_memlock
     effective_memlock=$(awk '$1 == "Max" && $2 == "locked" && $3 == "memory" { print $4 }' "/proc/$coord_pid/limits")
     [[ $effective_memlock == unlimited ]] || {

--- a/ds4_tp.c
+++ b/ds4_tp.c
@@ -244,6 +244,12 @@ static int tp_rdma_gid_is_ipv4_mapped(const union ibv_gid *gid) {
     return hi == 0 && mid == 0 && v4tag == 0xffff;
 }
 
+static int tp_rdma_gid_nonzero(const union ibv_gid *gid) {
+    for (int i = 0; i < 16; i++)
+        if (gid->raw[i]) return 1;
+    return 0;
+}
+
 #if defined(__linux__)
 static int tp_rdma_gid_type_sysfs(const char *device_name, int index) {
     char path[PATH_MAX];
@@ -879,10 +885,12 @@ static void tp_slab_layout(ds4_tp *tp) {
                        (uint64_t)tp->n_layer * DS4_TP_BATCH_MAX_ROWS * vec;
     tp->big_capacity_rows = tp_big_direct_max_rows();
 #ifdef DS4_TP_HAVE_VERBS
-    /* ConnectX-4 Lx on the reference gfx1151 nodes can pin/register the
-     * 152 MiB 2048-row layout but rejects the 270/481 MiB 4096/8192-row
-     * layouts with ENOMEM. OdinLink does not have this restriction. */
-    if (tp->rdma.is_mlx5 && tp->big_capacity_rows > 2048u)
+    /* Real NICs on the reference gfx1151 nodes can pin/register the
+     * 152 MiB 2048-row layout but reject the 270/481 MiB 4096/8192-row
+     * layouts (ConnectX-4 Lx with ENOMEM). OdinLink does not have this
+     * restriction. */
+    if (tp->rdma_active && !tp->rdma.is_odinlink &&
+        tp->big_capacity_rows > 2048u)
         tp->big_capacity_rows = 2048u;
 #endif
     tp->big_out_off = tp->batch_in_off +
@@ -1016,6 +1024,30 @@ static int tp_rdma_open(ds4_tp *tp, char *err, size_t errlen) {
     /* One verbs device per Thunderbolt port (rdma_enN); pick the active one
      * unless the caller selected a device explicitly. */
     const char *want_name = tp->opt.rdma_device;
+    if (!want_name) {
+        int active = 0;
+        char active_names[256] = "";
+        for (int i = 0; i < num; i++) {
+            const char *name = r->api.get_device_name(devs[i]);
+            struct ibv_context *ctx = r->api.open_device(devs[i]);
+            if (!ctx) continue;
+            struct ibv_port_attr pa;
+            if (r->api.query_port(ctx, 1, &pa) == 0 &&
+                pa.state == IBV_PORT_ACTIVE) {
+                active++;
+                size_t off = strlen(active_names);
+                snprintf(active_names + off, sizeof(active_names) - off,
+                         "%s%s", off ? ", " : "", name);
+            }
+            r->api.close_device(ctx);
+        }
+        if (active > 1)
+            fprintf(stderr,
+                    "ds4-tp: warning: %d verbs devices have an active port "
+                    "(%s); using the first in enumeration order. Pin the "
+                    "device with --rdma-device.\n",
+                    active, active_names);
+    }
     char states[256] = "";
     for (int i = 0; i < num && !r->ctx; i++) {
         const char *name = r->api.get_device_name(devs[i]);
@@ -1086,11 +1118,27 @@ static int tp_rdma_open(ds4_tp *tp, char *err, size_t errlen) {
                 break;
             }
         }
+#if defined(__linux__)
+        if (r->gid_index < 0 && !r->is_odinlink &&
+            r->port.link_layer == IBV_LINK_LAYER_INFINIBAND) {
+            /* A native InfiniBand port carries no IPv4 address in its GID
+             * table; the canonical entry is GID 0 (derived from the port
+             * GUID/LID). */
+            union ibv_gid tmp = {0};
+            const int gid_type = tp_rdma_query_gid_type(r, 0, &tmp);
+            if (gid_type >= 0 && tp_rdma_gid_nonzero(&tmp)) {
+                r->gid = tmp;
+                r->gid_index = 0;
+                r->gid_type = gid_type;
+            }
+        }
+#endif
         if (r->gid_index < 0) {
             tp_set_err(err, errlen,
-                       "tp rdma: no IPv4-mapped GID on the active port; give the "
-                       "Thunderbolt interface its own IPv4 (e.g. sudo ifconfig en1 "
-                       "inet 10.99.0.2/30 alias) on both machines");
+                       "tp rdma: no usable GID on the active port of %s; RoCE "
+                       "ports need the network interface to have its own IPv4 "
+                       "address on both machines",
+                       r->device_name);
             return 0;
         }
     }
@@ -1115,11 +1163,15 @@ static int tp_rdma_open(ds4_tp *tp, char *err, size_t errlen) {
     struct ibv_qp_init_attr qia = {0};
     qia.send_cq = r->cq;
     qia.recv_cq = r->cq;
-    /* DS4-TP-gfx1151 (patch 8): try UC, fall back to RC. OdinLink's verbs
-     * provider rejects everything except IBV_QPT_RC
-     * (odl_tb5_verbs_qp.c:250). RC keeps the connected, in-order semantics
-     * this transport depends on and merely adds reliability. */
-    qia.qp_type = r->is_mlx5 ? IBV_QPT_RC : IBV_QPT_UC;
+    /* DS4-TP-gfx1151 (patch 8): RC for every real (non-OdinLink) device.
+     * The exchange is full-duplex post-recv/post-send, and UC silently drops
+     * a SEND that reaches the peer before its RECV WR is armed (no RNR
+     * retry) -- on a low-latency native-IB link that leaves the peer's recv
+     * pending forever. RC's RNR retry keeps the connected, in-order
+     * semantics and closes the race. Only the OdinLink shim keeps the
+     * UC-first attempt; its verbs provider rejects UC and falls back to RC
+     * (odl_tb5_verbs_qp.c:250). */
+    qia.qp_type = r->is_odinlink ? IBV_QPT_UC : IBV_QPT_RC;
     qia.cap.max_send_wr = 256;
     qia.cap.max_recv_wr = 64;
     qia.cap.max_send_sge = 1;
@@ -1142,6 +1194,8 @@ static int tp_rdma_open(ds4_tp *tp, char *err, size_t errlen) {
     r->use_rc = qia.qp_type == IBV_QPT_RC;
     if (r->is_mlx5)
         fprintf(stderr, "ds4-tp: mlx5 queue pair uses RC\n");
+    else if (r->use_rc)
+        fprintf(stderr, "ds4-tp: %s queue pair uses RC\n", r->device_name);
     r->max_inline = qia.cap.max_inline_data;
 
     pthread_mutex_init(&r->post_lock, NULL);
@@ -1188,6 +1242,10 @@ static int tp_rdma_register_and_exchange(ds4_tp *tp, char *err, size_t errlen) {
                    (unsigned long long)core_bytes, strerror(errno));
         return 0;
     }
+    if (!r->is_mlx5)
+        fprintf(stderr,
+                "ds4-tp: %s registered slab as 1 MR (%.2f MiB)\n",
+                r->device_name, (double)core_bytes / 1048576.0);
     ds4_tp_rdma_info mine = {0};
     mine.slab_base = (uint64_t)(uintptr_t)tp->slab;
     mine.rkey = r->mr->rkey;
@@ -1246,7 +1304,9 @@ static int tp_rdma_register_and_exchange(ds4_tp *tp, char *err, size_t errlen) {
     a.ah_attr.grh.hop_limit = r->is_mlx5 ? 64 : 1;
     int rtr_mask = IBV_QP_STATE | IBV_QP_AV | IBV_QP_PATH_MTU |
                    IBV_QP_DEST_QPN | IBV_QP_RQ_PSN;
-    if (r->is_mlx5) {
+    /* RC-only attributes for non-OdinLink providers: the OdinLink shim's
+     * RC QP is validated without them. */
+    if (r->use_rc && !r->is_odinlink) {
         a.max_dest_rd_atomic = 1;
         a.min_rnr_timer = 12;
         rtr_mask |= IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;
@@ -1259,7 +1319,7 @@ static int tp_rdma_register_and_exchange(ds4_tp *tp, char *err, size_t errlen) {
     a.qp_state = IBV_QPS_RTS;
     a.sq_psn = mine.psn;
     int rts_mask = IBV_QP_STATE | IBV_QP_SQ_PSN;
-    if (r->is_mlx5) {
+    if (r->use_rc && !r->is_odinlink) {
         a.timeout = 14;
         a.retry_cnt = 7;
         a.rnr_retry = 7;
@@ -2382,7 +2442,11 @@ bool ds4_tp_big_gate_is_direct(const ds4_tp *tp, const void *out,
 }
 bool ds4_tp_requires_host_slab(const ds4_tp *tp) {
 #ifdef DS4_TP_HAVE_VERBS
-    return tp && tp->rdma_active && tp->rdma.is_mlx5;
+    /* Every real verbs device on these nodes registers the slab from
+     * host-mapped memory: VRAM hipMalloc addresses cannot be pinned as an
+     * MR (reg_mr EFAULT on mlx4, and the mlx5 path is host-slab by design).
+     * Only the OdinLink shim maps VRAM allocations itself. */
+    return tp && tp->rdma_active && !tp->rdma.is_odinlink;
 #else
     (void)tp;
     return false;

--- a/run-tp-ds4-bench.sh
+++ b/run-tp-ds4-bench.sh
@@ -83,8 +83,14 @@ case $RDMA_PROFILE in
     PEER_RDMA_DEVICE=${DS4_PEER_RDMA_DEVICE:-mlx5_1}
     RDMA_GID_INDEX=${DS4_RDMA_GID_INDEX:-3}
     ;;
+  ib-mlx4)
+    COORDINATOR_ADDR=${DS4_COORDINATOR_ADDR:-}
+    LOCAL_RDMA_DEVICE=${DS4_LOCAL_RDMA_DEVICE:-ibp195s0}
+    PEER_RDMA_DEVICE=${DS4_PEER_RDMA_DEVICE:-ibp195s0}
+    RDMA_GID_INDEX=${DS4_RDMA_GID_INDEX:-0}
+    ;;
   *)
-    echo "error: DS4_BENCH_RDMA_PROFILE must be odinlink or roce-v2" >&2
+    echo "error: DS4_BENCH_RDMA_PROFILE must be odinlink, roce-v2, or ib-mlx4" >&2
     exit 2
     ;;
 esac
@@ -601,6 +607,26 @@ if [[ $RDMA_PROFILE == odinlink ]]; then
   "${PEER_SSH[@]}" "test -r '$MODEL' -a -r /dev/odl_tb5_0 -a -r '$VERBS_LIB'" || {
     echo "error: peer model, OdinLink device, or provider unavailable" >&2; exit 1;
   }
+elif [[ $RDMA_PROFILE == ib-mlx4 ]]; then
+  [[ "$(cat "/sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/link_layer" 2>/dev/null)" == InfiniBand ]] || {
+    echo "error: local $LOCAL_RDMA_DEVICE is not a native InfiniBand port" >&2; exit 1;
+  }
+  [[ "$(cat "/sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/state" 2>/dev/null)" == "4: ACTIVE" ]] || {
+    echo "error: local $LOCAL_RDMA_DEVICE port is not ACTIVE" >&2; exit 1;
+  }
+  [[ "$(cat "/sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/lid" 2>/dev/null)" != 0x0 ]] || {
+    echo "error: local $LOCAL_RDMA_DEVICE has no LID; is a subnet manager running?" >&2; exit 1;
+  }
+  [[ -r /sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/gid_attrs/types/$RDMA_GID_INDEX ]] || {
+    echo "error: local GID index $RDMA_GID_INDEX unavailable: $LOCAL_RDMA_DEVICE" >&2; exit 1;
+  }
+  grep -qx 'IB/RoCE v1' \
+    "/sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/gid_attrs/types/$RDMA_GID_INDEX" || {
+    echo "error: local GID index $RDMA_GID_INDEX is not IB/RoCE v1" >&2; exit 1;
+  }
+  "${PEER_SSH[@]}" "test -r '$MODEL' && test \"\$(cat '/sys/class/infiniband/$PEER_RDMA_DEVICE/ports/1/link_layer')\" = InfiniBand && test \"\$(cat '/sys/class/infiniband/$PEER_RDMA_DEVICE/ports/1/state')\" = '4: ACTIVE' && test \"\$(cat '/sys/class/infiniband/$PEER_RDMA_DEVICE/ports/1/lid')\" != '0x0' && grep -qx 'IB/RoCE v1' '/sys/class/infiniband/$PEER_RDMA_DEVICE/ports/1/gid_attrs/types/$RDMA_GID_INDEX'" || {
+    echo "error: peer model or native-InfiniBand port unavailable" >&2; exit 1;
+  }
 else
   [[ -r /sys/class/infiniband/$LOCAL_RDMA_DEVICE/ports/1/gid_attrs/types/$RDMA_GID_INDEX ]] || {
     echo "error: local mlx5 RoCE device unavailable: $LOCAL_RDMA_DEVICE" >&2; exit 1;
@@ -924,13 +950,13 @@ if [[ $DECODE_SELF_CHECK == 1 ]]; then
       exit 1
     }
   "$REPO/scripts/check-tp-rdma-logs.sh" \
-    "$COORD_LOG" "$WORKER_LOG" "$RDMA_PROFILE"
+    "$COORD_LOG" "$WORKER_LOG" "$RDMA_PROFILE" "$LOCAL_RDMA_DEVICE" "${RDMA_GID_INDEX-}"
   echo "TP_DECODE_SELF_CHECK_PASSED"
   exit 0
 fi
 if [[ $TEACHER_FORCE_CONTROL == 1 ]]; then
   "$REPO/scripts/check-tp-rdma-logs.sh" \
-    "$COORD_LOG" "$WORKER_LOG" "$RDMA_PROFILE"
+    "$COORD_LOG" "$WORKER_LOG" "$RDMA_PROFILE" "$LOCAL_RDMA_DEVICE" "${RDMA_GID_INDEX-}"
   if [[ $RECORD_TEACHER_BASELINE == 1 ]]; then
     grep -E 'ds4-bench: teacher-force control complete .*mismatch_fnv64=[0-9a-f]{16} .*enforced=0' \
       "$COORD_LOG" || {
@@ -950,7 +976,7 @@ if [[ $TEACHER_FORCE_CONTROL == 1 ]]; then
 fi
 if [[ -n $FROZEN_TOKEN_FILE ]]; then
   "$REPO/scripts/check-tp-rdma-logs.sh" \
-    "$COORD_LOG" "$WORKER_LOG" "$RDMA_PROFILE"
+    "$COORD_LOG" "$WORKER_LOG" "$RDMA_PROFILE" "$LOCAL_RDMA_DEVICE" "${RDMA_GID_INDEX-}"
   completion=$(grep -E 'ds4-bench: frozen teacher logits complete prefix=[0-9]+ tokens=[0-9]+ ' \
     "$COORD_LOG" | tail -1 || true)
   [[ -n $completion ]] || {
@@ -992,6 +1018,6 @@ if [[ -n $FROZEN_TOKEN_FILE ]]; then
 fi
 "$REPO/scripts/check-ds4-bench-result.sh" \
   "$CSV" "$COORD_LOG" "$WORKER_LOG" "$EXPECTED_FNV64" "$TOKENS" "$CANDIDATE" \
-  "$RDMA_PROFILE"
+  "$RDMA_PROFILE" "$LOCAL_RDMA_DEVICE" "${RDMA_GID_INDEX-}"
 cat "$CSV"
 echo RUN_DONE

--- a/scripts/check-ds4-bench-result.sh
+++ b/scripts/check-ds4-bench-result.sh
@@ -9,6 +9,8 @@ EXPECTED_FNV64=${4:-}
 EXPECTED_TOKENS=${5:?missing expected generated-token count}
 REQUIRE_SEMANTIC=${6:-0}
 RDMA_PROFILE=${7:-odinlink}
+RDMA_DEVICE=${8:-}
+RDMA_GID_INDEX=${9:-}
 
 for path in "$CSV" "$COORD_LOG" "$WORKER_LOG"; do
   [[ -r $path ]] || { echo "error: missing benchmark evidence: $path" >&2; exit 1; }
@@ -62,7 +64,7 @@ ACTUAL_FNV64=$(read_csv_field gen_token_fnv64) || {
 }
 
 "$(dirname -- "$0")/check-tp-rdma-logs.sh" \
-  "$COORD_LOG" "$WORKER_LOG" "$RDMA_PROFILE"
+  "$COORD_LOG" "$WORKER_LOG" "$RDMA_PROFILE" "$RDMA_DEVICE" "$RDMA_GID_INDEX"
 if [[ $REQUIRE_SEMANTIC == 1 ]]; then
   grep -q 'ds4-bench: semantic suite passed cases=2' "$COORD_LOG" || {
     echo "error: candidate did not pass the complete semantic suite; rejecting result" >&2

--- a/scripts/check-tp-rdma-logs.sh
+++ b/scripts/check-tp-rdma-logs.sh
@@ -3,9 +3,11 @@
 # kernel failures. Shared by timed results and pre-timing diagnostic gates.
 set -euo pipefail
 
-COORD_LOG=${1:?usage: check-tp-rdma-logs.sh COORD_LOG WORKER_LOG RDMA_PROFILE}
+COORD_LOG=${1:?usage: check-tp-rdma-logs.sh COORD_LOG WORKER_LOG RDMA_PROFILE [RDMA_DEVICE [RDMA_GID_INDEX]]}
 WORKER_LOG=${2:?missing worker log}
 RDMA_PROFILE=${3:-odinlink}
+RDMA_DEVICE=${4:-}
+RDMA_GID_INDEX=${5:-}
 
 for path in "$COORD_LOG" "$WORKER_LOG"; do
   [[ -r $path ]] || { echo "error: missing TP log: $path" >&2; exit 1; }
@@ -38,6 +40,30 @@ case $RDMA_PROFILE in
       }
       ! grep -q 'rdma device odl_tb5_' "$log" || {
         echo "error: RoCE run unexpectedly used OdinLink: $log" >&2
+        exit 1
+      }
+    done
+    ;;
+  ib-mlx4)
+    [[ -n $RDMA_DEVICE ]] || {
+      echo "error: ib-mlx4 profile requires the RDMA device name as the 4th argument" >&2
+      exit 2
+    }
+    for log in "$COORD_LOG" "$WORKER_LOG"; do
+      grep -qF "rdma device $RDMA_DEVICE " "$log" &&
+      grep -Eq "rdma GID index ${RDMA_GID_INDEX:-0}([[:space:]]|$)" "$log" &&
+      grep -q 'registered slab as 1 MR' "$log" &&
+      grep -qF "$RDMA_DEVICE queue pair uses RC" "$log" &&
+      grep -qF 'rdma decode message policy 16384 bytes (generic provider)' "$log" || {
+        echo "error: log does not prove mlx4 native-InfiniBand with single-MR registration: $log" >&2
+        exit 1
+      }
+      ! grep -q 'rdma device odl_tb5_' "$log" || {
+        echo "error: InfiniBand run unexpectedly used OdinLink: $log" >&2
+        exit 1
+      }
+      ! grep -q 'RoCE v2' "$log" || {
+        echo "error: InfiniBand run unexpectedly used a RoCE v2 GID: $log" >&2
         exit 1
       }
     done

--- a/tests/roce_v2_mr_probe.cpp
+++ b/tests/roce_v2_mr_probe.cpp
@@ -18,8 +18,8 @@ static uint64_t ds4_slab_bytes(uint32_t layers, uint32_t embd,
 
 static void usage(const char *argv0) {
     std::fprintf(stderr,
-                 "usage: %s <mlx5-device> [layers=61] [embd=4096] "
-                 "[big-rows=2048]\n",
+                  "usage: %s <rdma-device> [layers=61] [embd=4096] "
+                  "[big-rows=2048]\n",
                  argv0);
 }
 
@@ -97,15 +97,28 @@ int main(int argc, char **argv) {
         const uint64_t big_bytes = (uint64_t)big_rows * embd * sizeof(float);
         const uint64_t core_bytes = bytes - 2 * big_bytes;
         ibv_mr *segments[3] = {};
+        ibv_mr *single = nullptr;
         if (hip_rc == hipSuccess) {
-            segments[0] = ibv_reg_mr(pd, host_slab, (size_t)core_bytes, access);
-            segments[1] = ibv_reg_mr(pd, (char *)host_slab + core_bytes,
-                                     (size_t)big_bytes, access);
-            segments[2] = ibv_reg_mr(pd,
-                                     (char *)host_slab + core_bytes + big_bytes,
-                                     (size_t)big_bytes, access);
+            single = ibv_reg_mr(pd, host_slab, (size_t)bytes, access);
+            if (!single) {
+                segments[0] =
+                    ibv_reg_mr(pd, host_slab, (size_t)core_bytes, access);
+                segments[1] = ibv_reg_mr(pd, (char *)host_slab + core_bytes,
+                                         (size_t)big_bytes, access);
+                segments[2] = ibv_reg_mr(
+                    pd, (char *)host_slab + core_bytes + big_bytes,
+                    (size_t)big_bytes, access);
+            }
         }
-        if (segments[0] && segments[1] && segments[2]) {
+        if (single) {
+            std::printf("PASS device=%s allocator=hipHostMallocMapped "
+                        "bytes=%" PRIu64 " lkey=0x%x rkey=0x%x mr_layout=1 "
+                        "memlock_soft=%" PRIu64 " memlock_hard=%" PRIu64 "\n",
+                        argv[1], bytes, single->lkey, single->rkey,
+                        (uint64_t)lim.rlim_cur, (uint64_t)lim.rlim_max);
+            ibv_dereg_mr(single);
+            mr = (ibv_mr *)(uintptr_t)1;
+        } else if (segments[0] && segments[1] && segments[2]) {
             std::printf("PASS device=%s allocator=hipHostMallocMapped "
                         "bytes=%" PRIu64 " mr_layout=3 core=%" PRIu64
                         " big=%" PRIu64 " memlock_soft=%" PRIu64

--- a/tests/test_bench_env_precedence.sh
+++ b/tests/test_bench_env_precedence.sh
@@ -11,6 +11,25 @@ printf '%s\n' \
   'DS4_COORDINATOR_ADDR=192.168.99.1' \
   > "$config"
 
+# Minimal GGUF whose only metadata is general.architecture; the harness
+# inspects the model architecture before its validate-config exit, so
+# /dev/null is unusable as the model argument.
+model=$test_dir/model.gguf
+python3 - "$model" <<'PY'
+import struct, sys
+def s(x):
+    b = x.encode()
+    return struct.pack('<Q', len(b)) + b
+with open(sys.argv[1], 'wb') as f:
+    f.write(b'GGUF')
+    f.write(struct.pack('<I', 3))
+    f.write(struct.pack('<Q', 0))
+    f.write(struct.pack('<Q', 1))
+    f.write(s('general.architecture'))
+    f.write(struct.pack('<I', 8))
+    f.write(s('deepseek4'))
+PY
+
 run_validate() {
   env -i PATH="$PATH" LANG=C.UTF-8 \
     DS4_BENCH_CONFIG="$config" \
@@ -18,7 +37,7 @@ run_validate() {
     DS4_BENCH_DSPARK=1 \
     DS4_BENCH_PROMPT_FILE=/dev/null \
     "$@" \
-    "$repo/run-tp-ds4-bench.sh" env-precedence /dev/null
+    "$repo/run-tp-ds4-bench.sh" env-precedence "$model"
 }
 
 expect_contains() {
@@ -69,8 +88,13 @@ if run_validate DS4_BENCH_RDMA_PROFILE=bogus >"$test_dir/bogus.out" 2>&1; then
   echo 'FAIL invalid-provider-still-rejected: unexpectedly succeeded' >&2
   exit 1
 fi
-grep -q 'must be odinlink or roce-v2' "$test_dir/bogus.out"
+grep -q 'must be odinlink, roce-v2, or ib-mlx4' "$test_dir/bogus.out"
 echo 'PASS invalid-provider-still-rejected'
+
+expect_contains ib-mlx4-profile-defaults \
+  'rdma_profile=ib-mlx4 coordinator_addr=192.168.100.1 coordinator_rdma_device=ibp195s0 worker_rdma_device=ibp195s0 rdma_gid_index=0 prefill_chunk=4096' \
+  DS4_BENCH_RDMA_PROFILE=ib-mlx4 \
+  DS4_COORDINATOR_ADDR=192.168.100.1
 
 if env -i PATH="$PATH" LANG=C.UTF-8 \
     DS4_BENCH_CONFIG="$config" \
@@ -78,7 +102,7 @@ if env -i PATH="$PATH" LANG=C.UTF-8 \
     DS4_BENCH_DSPARK=1 \
     DS4_BENCH_PROMPT_FILE=/dev/null \
     DS4_TP_EXPERT_SPLIT=118 \
-    "$repo/run-tp-ds4-bench.sh" env-precedence /dev/null \
+    "$repo/run-tp-ds4-bench.sh" env-precedence "$model" \
     >"$test_dir/split.out" 2>&1; then
   echo 'FAIL ambient-expert-split-still-rejected: unexpectedly succeeded' >&2
   exit 1

--- a/tests/test_container_security_static.sh
+++ b/tests/test_container_security_static.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+repo=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+launcher=$repo/deploy/ds4-tp-caddy.sh
+config=$repo/deploy/config.env.example
+containerfile=$repo/deploy/Containerfile.rocm714-rdma
+
+grep -q 'DS4_TP_CONTAINER_IMAGE_ID' "$launcher"
+grep -q 'DS4_TP_CONTAINER_IMAGE_ID must be the 64-hex content ID' "$launcher"
+grep -q 'peer container image ID differs' "$launcher"
+grep -q -- '--entrypoint /bin/bash' "$launcher"
+grep -q -- '--cap-drop=all' "$launcher"
+grep -q -- '--security-opt no-new-privileges' "$launcher"
+grep -q -- '--group-add keep-groups' "$launcher"
+grep -q -- ':ro' "$launcher"
+grep -q '^FROM .*@sha256:' "$containerfile"
+grep -q 'ibverbs-providers=' "$containerfile"
+grep -q 'ibverbs-utils=' "$containerfile"
+grep -q 'command -v ibv_devinfo' "$launcher"
+
+if grep -q -- '--security-opt label=disable' "$launcher"; then
+  echo 'FAIL label separation is disabled by default' >&2
+  exit 1
+fi
+if grep -q -- '--security-opt unmask=all' "$launcher"; then
+  echo 'FAIL all masked paths are unmasked by default' >&2
+  exit 1
+fi
+if grep -q 'src=/usr/lib/.*/libibverbs' "$launcher"; then
+  echo 'FAIL host libibverbs providers are mounted into the container' >&2
+  exit 1
+fi
+grep -q 'same content-addressed image ID' "$config"
+if grep -q 'DS4_TP_CONTAINER_VOLUME=/home' "$config"; then
+  echo 'FAIL example mounts a home directory' >&2
+  exit 1
+fi
+echo 'PASS container-security-static'


### PR DESCRIPTION
Supersedes #1 with the contributor's mlx4 transport commits plus reviewed container hardening.

Security/runtime changes:
- content-addressed image parity across both independent nodes
- rootless, zero capabilities, no-new-privileges
- read-only artifacts and separate writable runtime volume
- narrow GPU/RDMA devices and read-only InfiniBand sysfs
- container-native, version-pinned verbs providers; no host library injection
- DS4/glibc and `ibv_devinfo` preflight before model loading
- fail-closed peer cleanup on coordinator startup failure

Validation:
- `bash -n deploy/ds4-tp-caddy.sh`
- `tests/test_container_security_static.sh`
- `tests/test_bench_env_precedence.sh`
- `tests/test_research_root_contract.sh`
- live two-node rootless container TP=2 over mlx5 RoCE v2
- API health and 300-token completion
- `validated_rdma_profile=roce-v2`, RC, three MRs, zero fallback
- runtime `CapEff=0`, `NoNewPrivs=1`, clean two-rank shutdown

Native mlx4 remains opt-in because the reference machines only have mlx5 hardware. Existing non-container OdinLink/RoCE paths are unchanged.
