### PR TITLE
deploy: pin OdinLink GID interface on both ranks

### DIFF
--- a/deploy/config.env.example
+++ b/deploy/config.env.example
@@ -60,6 +60,9 @@ RDMA_PROFILE=odinlink
 # Both independent filesystems must contain this repository at this path.
 PEER_REPO=/absolute/path/ds4-strix-halo-tp-odinlink
 ODINLINK_ROOT=/absolute/path/OdinLink-Five
+# Interface whose IPv4 address OdinLink advertises as its RDMA GID. Set this
+# explicitly when a host has multiple USB4/Thunderbolt network interfaces.
+ODL_RDMA_GID_IFACE=thunderbolt0
 # Research output lives outside every Git worktree. The peer may use a
 # different absolute path because the two filesystems are independent.
 DS4_RESEARCH_ROOT=/absolute/path/research-results

--- a/deploy/ds4-tp-caddy.sh
+++ b/deploy/ds4-tp-caddy.sh
@@ -465,7 +465,8 @@ start() {
     common=(env
       DS4_TP_ODINLINK_BATCH_ASYNC=1
       DS4_TP_VERBS_LIB="$VERBS_LIB"
-      LD_LIBRARY_PATH="$ODL_LD_PATH")
+      LD_LIBRARY_PATH="$ODL_LD_PATH"
+      ODL_RDMA_GID_IFACE="${ODL_RDMA_GID_IFACE:-thunderbolt0}")
     worker_rdma_args=(--rdma-device "$PEER_RDMA_DEVICE")
     coordinator_rdma_args=(--rdma-device "$LOCAL_RDMA_DEVICE")
   else


### PR DESCRIPTION
## Summary

- pass `ODL_RDMA_GID_IFACE` explicitly to both independently launched TP ranks
- document the `thunderbolt0` default for multi-interface USB4 hosts

## Why

OdinLink's verbs provider derives its advertised RDMA GID from a network interface. On hosts with multiple USB4/Thunderbolt interfaces, relying on process-local autodetection can select a different interface on each independent filesystem/rank. The deployment config already names the intended interface; this change carries it into the shared environment used for both processes.

## Validation

- `bash -n deploy/ds4-tp-caddy.sh`
- container security and ownership tests pass
- `git diff --check`
- deployment preflight passes on nodes 182/224
- live coordinator and worker environments both contain `ODL_RDMA_GID_IFACE=thunderbolt0`
- no model, arithmetic, cache, transport protocol, clock, power, or kernel-driver changes
